### PR TITLE
Add Spanish language support

### DIFF
--- a/.github/workflows/scripts/convert.sh
+++ b/.github/workflows/scripts/convert.sh
@@ -31,6 +31,7 @@ jq -r '
     translations: {
       "de": .value.localizations.de.stringUnit.value,
       "en": .value.localizations.en.stringUnit.value,
+      "es": .value.localizations.es.stringUnit.value,
       "fr": .value.localizations.fr.stringUnit.value,
       "ja": .value.localizations.ja.stringUnit.value,
       "ko": .value.localizations.ko.stringUnit.value,

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ RunCat uses [SystemInfoKit](https://github.com/Kyome22/SystemInfoKit), so locali
 - German
 - Japanese
 - Korean
+- Spanish
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ RunCat uses [SystemInfoKit](https://github.com/Kyome22/SystemInfoKit), so locali
 - German
 - Japanese
 - Korean
-- Spanish
 
 ## Requirements
 

--- a/Sources/RunCatLocalization/RCLLanguage.swift
+++ b/Sources/RunCatLocalization/RCLLanguage.swift
@@ -9,6 +9,7 @@ public enum RCLLanguage: Sendable, Identifiable {
     case german
     case japanese
     case korean
+    case spanish
 
     public var locale: Locale {
         switch self {
@@ -28,6 +29,8 @@ public enum RCLLanguage: Sendable, Identifiable {
             Locale(languageCode: .japanese)
         case .korean:
             Locale(languageCode: .korean)
+        case .spanish:
+            Locale(languageCode: .spanish)
         }
     }
 
@@ -49,5 +52,6 @@ public enum RCLLanguage: Sendable, Identifiable {
         .german,
         .japanese,
         .korean,
+        .spanish,
     ]
 }

--- a/Sources/RunCatLocalization/RCLLanguage.swift
+++ b/Sources/RunCatLocalization/RCLLanguage.swift
@@ -9,7 +9,6 @@ public enum RCLLanguage: Sendable, Identifiable {
     case german
     case japanese
     case korean
-    case spanish
 
     public var locale: Locale {
         switch self {
@@ -29,8 +28,6 @@ public enum RCLLanguage: Sendable, Identifiable {
             Locale(languageCode: .japanese)
         case .korean:
             Locale(languageCode: .korean)
-        case .spanish:
-            Locale(languageCode: .spanish)
         }
     }
 
@@ -52,6 +49,5 @@ public enum RCLLanguage: Sendable, Identifiable {
         .german,
         .japanese,
         .korean,
-        .spanish,
     ]
 }

--- a/Sources/RunCatLocalization/Resources/Dashboard.xcstrings
+++ b/Sources/RunCatLocalization/Resources/Dashboard.xcstrings
@@ -44,6 +44,12 @@
             "state" : "translated",
             "value" : "關於 RunCat"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acerca de RunCat"
+          }
         }
       }
     },
@@ -89,6 +95,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活動監視器"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monitor de actividad"
           }
         }
       }
@@ -136,6 +148,12 @@
             "state" : "translated",
             "value" : "返回"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atrás"
+          }
         }
       }
     },
@@ -181,6 +199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "動物類跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores de tipo animal"
           }
         }
       }
@@ -228,6 +252,12 @@
             "state" : "translated",
             "value" : "預設跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores predeterminados"
+          }
         }
       }
     },
@@ -273,6 +303,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "非生物類跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores de tipo inanimado"
           }
         }
       }
@@ -320,6 +356,12 @@
             "state" : "translated",
             "value" : "季節限定跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores estacionales"
+          }
         }
       }
     },
@@ -365,6 +407,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自製跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores personalizados"
           }
         }
       }
@@ -412,6 +460,12 @@
             "state" : "translated",
             "value" : "特殊色跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores de colores especiales"
+          }
         }
       }
     },
@@ -457,6 +511,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "貢獻 RunCat"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contribuir a RunCat"
           }
         }
       }
@@ -504,6 +564,12 @@
             "state" : "translated",
             "value" : "偵錯睡眠"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depuración del modo reposo"
+          }
         }
       }
     },
@@ -549,6 +615,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "偵錯喚醒"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depuración de la reactivación"
           }
         }
       }
@@ -596,6 +668,12 @@
             "state" : "translated",
             "value" : "玩無盡遊戲"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jugar al juego infinito"
+          }
         }
       }
     },
@@ -642,6 +720,12 @@
             "state" : "translated",
             "value" : "幫助"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ayuda"
+          }
         }
       }
     },
@@ -687,6 +771,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "常見問題"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preguntas frecuentes"
           }
         }
       }
@@ -735,6 +825,12 @@
             "state" : "translated",
             "value" : "如何添加自製跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cómo agregar corredores personalizados"
+          }
         }
       }
     },
@@ -780,6 +876,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更多"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más"
           }
         }
       }
@@ -827,6 +929,12 @@
             "state" : "translated",
             "value" : "回報問題"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reportar un problema"
+          }
         }
       }
     },
@@ -872,6 +980,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores"
           }
         }
       }
@@ -919,6 +1033,12 @@
             "state" : "translated",
             "value" : "自製"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personalizado"
+          }
         }
       }
     },
@@ -964,6 +1084,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuración"
           }
         }
       }
@@ -1011,6 +1137,12 @@
             "state" : "translated",
             "value" : "商店"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tienda"
+          }
         }
       }
     },
@@ -1056,6 +1188,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "結束 RunCat"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salir de RunCat"
           }
         }
       }

--- a/Sources/RunCatLocalization/Resources/Dashboard.xcstrings
+++ b/Sources/RunCatLocalization/Resources/Dashboard.xcstrings
@@ -44,6 +44,12 @@
             "state" : "translated",
             "value" : "關於 RunCat"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acerca de RunCat"
+          }
         }
       }
     },
@@ -89,6 +95,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活動監視器"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monitor de actividad"
           }
         }
       }
@@ -136,6 +148,12 @@
             "state" : "translated",
             "value" : "返回"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atrás"
+          }
         }
       }
     },
@@ -181,6 +199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "動物類跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores de tipo animal"
           }
         }
       }
@@ -228,6 +252,12 @@
             "state" : "translated",
             "value" : "預設跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores predeterminados"
+          }
         }
       }
     },
@@ -273,6 +303,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "非生物類跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores de tipo inanimado"
           }
         }
       }
@@ -320,6 +356,12 @@
             "state" : "translated",
             "value" : "季節限定跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores estacionales"
+          }
         }
       }
     },
@@ -365,6 +407,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自製跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores personalizados"
           }
         }
       }
@@ -412,6 +460,12 @@
             "state" : "translated",
             "value" : "特殊色跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores de colores especiales"
+          }
         }
       }
     },
@@ -457,6 +511,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "貢獻 RunCat"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contribuir a RunCat"
           }
         }
       }
@@ -504,6 +564,12 @@
             "state" : "translated",
             "value" : "偵錯睡眠"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depurar suspensión"
+          }
         }
       }
     },
@@ -549,6 +615,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "偵錯喚醒"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depurar reactivación"
           }
         }
       }
@@ -596,6 +668,12 @@
             "state" : "translated",
             "value" : "玩無盡遊戲"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " juego infinito"
+          }
         }
       }
     },
@@ -642,6 +720,12 @@
             "state" : "translated",
             "value" : "幫助"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ayuda"
+          }
         }
       }
     },
@@ -687,6 +771,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "常見問題"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preguntas frecuentes"
           }
         }
       }
@@ -735,6 +825,12 @@
             "state" : "translated",
             "value" : "如何添加自製跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cómo agregar corredores personalizados"
+          }
         }
       }
     },
@@ -780,6 +876,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更多"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más"
           }
         }
       }
@@ -827,6 +929,12 @@
             "state" : "translated",
             "value" : "回報問題"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reportar un problema"
+          }
         }
       }
     },
@@ -872,6 +980,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores"
           }
         }
       }
@@ -919,6 +1033,12 @@
             "state" : "translated",
             "value" : "自製"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personalizado"
+          }
         }
       }
     },
@@ -964,6 +1084,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuración"
           }
         }
       }
@@ -1011,6 +1137,12 @@
             "state" : "translated",
             "value" : "商店"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tienda"
+          }
         }
       }
     },
@@ -1056,6 +1188,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "結束 RunCat"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salir de RunCat"
           }
         }
       }

--- a/Sources/RunCatLocalization/Resources/Dashboard.xcstrings
+++ b/Sources/RunCatLocalization/Resources/Dashboard.xcstrings
@@ -44,12 +44,6 @@
             "state" : "translated",
             "value" : "關於 RunCat"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acerca de RunCat"
-          }
         }
       }
     },
@@ -95,12 +89,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活動監視器"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monitor de actividad"
           }
         }
       }
@@ -148,12 +136,6 @@
             "state" : "translated",
             "value" : "返回"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atrás"
-          }
         }
       }
     },
@@ -199,12 +181,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "動物類跑者"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Corredores de tipo animal"
           }
         }
       }
@@ -252,12 +228,6 @@
             "state" : "translated",
             "value" : "預設跑者"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Corredores predeterminados"
-          }
         }
       }
     },
@@ -303,12 +273,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "非生物類跑者"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Corredores de tipo inanimado"
           }
         }
       }
@@ -356,12 +320,6 @@
             "state" : "translated",
             "value" : "季節限定跑者"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Corredores estacionales"
-          }
         }
       }
     },
@@ -407,12 +365,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自製跑者"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Corredores personalizados"
           }
         }
       }
@@ -460,12 +412,6 @@
             "state" : "translated",
             "value" : "特殊色跑者"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Corredores de colores especiales"
-          }
         }
       }
     },
@@ -511,12 +457,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "貢獻 RunCat"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contribuir a RunCat"
           }
         }
       }
@@ -564,12 +504,6 @@
             "state" : "translated",
             "value" : "偵錯睡眠"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Depurar suspensión"
-          }
         }
       }
     },
@@ -615,12 +549,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "偵錯喚醒"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Depurar reactivación"
           }
         }
       }
@@ -668,12 +596,6 @@
             "state" : "translated",
             "value" : "玩無盡遊戲"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " juego infinito"
-          }
         }
       }
     },
@@ -720,12 +642,6 @@
             "state" : "translated",
             "value" : "幫助"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayuda"
-          }
         }
       }
     },
@@ -771,12 +687,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "常見問題"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preguntas frecuentes"
           }
         }
       }
@@ -825,12 +735,6 @@
             "state" : "translated",
             "value" : "如何添加自製跑者"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cómo agregar corredores personalizados"
-          }
         }
       }
     },
@@ -876,12 +780,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更多"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Más"
           }
         }
       }
@@ -929,12 +827,6 @@
             "state" : "translated",
             "value" : "回報問題"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reportar un problema"
-          }
         }
       }
     },
@@ -980,12 +872,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跑者"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Corredores"
           }
         }
       }
@@ -1033,12 +919,6 @@
             "state" : "translated",
             "value" : "自製"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personalizado"
-          }
         }
       }
     },
@@ -1084,12 +964,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuración"
           }
         }
       }
@@ -1137,12 +1011,6 @@
             "state" : "translated",
             "value" : "商店"
           }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tienda"
-          }
         }
       }
     },
@@ -1188,12 +1056,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "結束 RunCat"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salir de RunCat"
           }
         }
       }

--- a/Sources/RunCatLocalization/Resources/GeneralSettings.xcstrings
+++ b/Sources/RunCatLocalization/Resources/GeneralSettings.xcstrings
@@ -1,650 +1,734 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "allRunners" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aus allen Läufern wählen"
+  "sourceLanguage": "en",
+  "strings": {
+    "allRunners": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus allen Läufern wählen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select from all runners"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select from all runners"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionne tous les coureurs"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionne tous les coureurs"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "全てのランナーから選択する"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全てのランナーから選択する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "모든 러너중에서 선택"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 러너중에서 선택"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所有跑者"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有跑者"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇所有跑者"
-          }
-        }
-      }
-    },
-    "changedMyMind" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ich habe meine Meinung geändert"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇所有跑者"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changed my mind"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mon avis a changé"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "気が変わった"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "그냥 둘래요"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "我改变主意了"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "我改變主意了"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar de todos los corredores"
           }
         }
       }
     },
-    "flipHorizontally" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Horizontal spiegeln"
+    "changedMyMind": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ich habe meine Meinung geändert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flip horizontally"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changed my mind"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inverser horizontalement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mon avis a changé"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "左右を反転"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "気が変わった"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "수평 반전"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "그냥 둘래요"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "水平翻转"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我改变主意了"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "水平翻轉"
-          }
-        }
-      }
-    },
-    "invertSpeed" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geschwindigkeit umkehren"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我改變主意了"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Invert speed"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inverser la vitesse"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "速度を反転"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "속도 반전"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "速度反转"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "速度反轉"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambié de opinión"
           }
         }
       }
     },
-    "launch" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starten"
+    "flipHorizontally": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Horizontal spiegeln"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Launch"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flip horizontally"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Démarrage"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inverser horizontalement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "起動"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左右を反転"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "자동 실행"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수평 반전"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启动"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水平翻转"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "啟動"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水平翻轉"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voltear horizontalmente"
           }
         }
       }
     },
-    "launchAtLogin" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RunCat automatisch beim Einloggen starten."
+    "invertSpeed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geschwindigkeit umkehren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Launch RunCat automatically at login."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invert speed"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir automatiquement RunCat avec la session."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inverser la vitesse"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ログイン時に自動でRunCatを起動"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "速度を反転"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "로그인 시 RunCat을 자동 실행"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "속도 반전"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "登录时自启 RunCat"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "速度反转"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "登入時自動啟動 RunCat"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "速度反轉"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invertir velocidad"
           }
         }
       }
     },
-    "onlyMonochromeRunners" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nur aus einfarbigen Läufern wählen"
+    "launch": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select from only monochrome runners"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionne seulement les coureurs monochrome"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrage"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "モノクロのランナーのみから選択する"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "起動"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "흑백 러너중에서 선택"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 실행"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "仅单色跑者"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇僅單色跑者"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟動"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar"
           }
         }
       }
     },
-    "runner" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Läufer"
+    "launchAtLogin": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RunCat automatisch beim Einloggen starten."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Runner"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch RunCat automatically at login."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coureur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir automatiquement RunCat avec la session."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ランナー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログイン時に自動でRunCatを起動"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "러너"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 시 RunCat을 자동 실행"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跑者"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录时自启 RunCat"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跑者"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登入時自動啟動 RunCat"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar RunCat automáticamente al iniciar sesión."
           }
         }
       }
     },
-    "selectAutomatically" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle 10 Minuten automatisch zufällig auswählen"
+    "onlyMonochromeRunners": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur aus einfarbigen Läufern wählen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select randomly per 10 minutes automatically"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select from only monochrome runners"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélection aléatoire toutes les 10 minutes"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionne seulement les coureurs monochrome"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10分ごとにランダムで自動選択"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モノクロのランナーのみから選択する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10분마다 랜덤하게 러너 바꾸기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "흑백 러너중에서 선택"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "每 10 分钟随机一个"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅单色跑者"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "每 10 分鐘隨機選擇"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇僅單色跑者"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar solo de corredores monocromáticos"
           }
         }
       }
     },
-    "stop" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Läufer anhalten"
+    "runner": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läufer"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop the runner"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runner"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrêter le coureur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coureur"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止する"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ランナー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "러너 멈추기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "러너"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跑者"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止跑者"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跑者"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corredor"
           }
         }
       }
     },
-    "stopRunner" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Läufer anhalten"
+    "selectAutomatically": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle 10 Minuten automatisch zufällig auswählen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop the runner"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select randomly per 10 minutes automatically"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrêter le coureur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélection aléatoire toutes les 10 minutes"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ランナーを停止"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10分ごとにランダムで自動選択"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "러너를 멈춰주세요"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10분마다 랜덤하게 러너 바꾸기"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止跑者"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每 10 分钟随机一个"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "停止跑者"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每 10 分鐘隨機選擇"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar aleatoriamente cada 10 minutos automáticamente"
           }
         }
       }
     },
-    "stopRunnerMessage" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn Du den Läufer anhälst, geht die Einzigartigkeit dieser Anwendung verloren."
+    "stop": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läufer anhalten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If you stop the runner, the uniqueness of this application will be lost."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop the runner"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si vous arrêter les mouvements du coureur, le caractère unique de l’application sera perdu."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter le coureur"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ランナーを停止してしまうと本アプリの独自性が失われます。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "만약 러너를 멈춘다면, 이 애플리케이션의 특징을 잃게됩니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "러너 멈추기"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果停止跑者，就会失去软件的趣味性"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果你停止了跑者，就會失去此 App 的獨特性"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止跑者"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detener el corredor"
           }
         }
       }
     },
-    "stopRunnerTitle" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Möchtest Du den Läufer wirklich anhalten?"
+    "stopRunner": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läufer anhalten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Do you really want to stop the runner?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop the runner"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voulez-vous vraiment arrêter les mouvements du coureur ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrêter le coureur"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "本当にランナーを停止しても良いですか？"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ランナーを停止"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "정말로 러너를 멈추시겠습니까?"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "러너를 멈춰주세요"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你确定要停止跑者吗？"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止跑者"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你確定要停止跑者嗎？"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止跑者"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detener el corredor"
           }
         }
       }
     },
-    "useAccentColor" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwende die Akzentfarbe des Systems"
+    "stopRunnerMessage": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn Du den Läufer anhälst, geht die Einzigartigkeit dieser Anwendung verloren."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use the system accent color"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you stop the runner, the uniqueness of this application will be lost."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utiliser la couleur d’accentuation du système"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si vous arrêter les mouvements du coureur, le caractère unique de l’application sera perdu."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システムのアクセントカラーを使用"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ランナーを停止してしまうと本アプリの独自性が失われます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "시스템 강조 색상 사용"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "만약 러너를 멈춘다면, 이 애플리케이션의 특징을 잃게됩니다."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用系统强调色"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果停止跑者，就会失去软件的趣味性"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用系統主題色"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果你停止了跑者，就會失去此 App 的獨特性"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si detienes el corredor, se perderá la singularidad de esta aplicación."
+          }
+        }
+      }
+    },
+    "stopRunnerTitle": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Möchtest Du den Läufer wirklich anhalten?"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do you really want to stop the runner?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voulez-vous vraiment arrêter les mouvements du coureur ?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本当にランナーを停止しても良いですか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정말로 러너를 멈추시겠습니까?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你确定要停止跑者吗？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你確定要停止跑者嗎？"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Realmente quieres detener el corredor?"
+          }
+        }
+      }
+    },
+    "useAccentColor": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwende die Akzentfarbe des Systems"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use the system accent color"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser la couleur d’accentuation du système"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムのアクセントカラーを使用"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 강조 색상 사용"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用系统强调色"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用系統主題色"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar el color de acento del sistema"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/Sources/RunCatLocalization/Resources/GeneralSettings.xcstrings
+++ b/Sources/RunCatLocalization/Resources/GeneralSettings.xcstrings
@@ -1,734 +1,650 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "allRunners": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aus allen Läufern wählen"
+  "sourceLanguage" : "en",
+  "strings" : {
+    "allRunners" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aus allen Läufern wählen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select from all runners"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select from all runners"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélectionne tous les coureurs"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionne tous les coureurs"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全てのランナーから選択する"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全てのランナーから選択する"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모든 러너중에서 선택"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 러너중에서 선택"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所有跑者"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有跑者"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選擇所有跑者"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccionar de todos los corredores"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇所有跑者"
           }
         }
       }
     },
-    "changedMyMind": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ich habe meine Meinung geändert"
+    "changedMyMind" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ich habe meine Meinung geändert"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Changed my mind"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changed my mind"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mon avis a changé"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mon avis a changé"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "気が変わった"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "気が変わった"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "그냥 둘래요"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "그냥 둘래요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "我改变主意了"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我改变主意了"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "我改變主意了"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambié de opinión"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我改變主意了"
           }
         }
       }
     },
-    "flipHorizontally": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Horizontal spiegeln"
+    "flipHorizontally" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Horizontal spiegeln"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Flip horizontally"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flip horizontally"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inverser horizontalement"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inverser horizontalement"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "左右を反転"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左右を反転"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "수평 반전"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수평 반전"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水平翻转"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水平翻转"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水平翻轉"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voltear horizontalmente"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水平翻轉"
           }
         }
       }
     },
-    "invertSpeed": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geschwindigkeit umkehren"
+    "invertSpeed" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geschwindigkeit umkehren"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invert speed"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invert speed"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inverser la vitesse"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inverser la vitesse"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "速度を反転"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "速度を反転"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "속도 반전"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "속도 반전"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "速度反转"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "速度反转"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "速度反轉"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invertir velocidad"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "速度反轉"
           }
         }
       }
     },
-    "launch": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Starten"
+    "launch" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starten"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Launch"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Launch"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Démarrage"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Démarrage"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "起動"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "起動"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "자동 실행"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 실행"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "启动"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "啟動"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iniciar"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟動"
           }
         }
       }
     },
-    "launchAtLogin": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "RunCat automatisch beim Einloggen starten."
+    "launchAtLogin" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RunCat automatisch beim Einloggen starten."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Launch RunCat automatically at login."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Launch RunCat automatically at login."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ouvrir automatiquement RunCat avec la session."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir automatiquement RunCat avec la session."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ログイン時に自動でRunCatを起動"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログイン時に自動でRunCatを起動"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "로그인 시 RunCat을 자동 실행"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로그인 시 RunCat을 자동 실행"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "登录时自启 RunCat"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登录时自启 RunCat"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "登入時自動啟動 RunCat"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iniciar RunCat automáticamente al iniciar sesión."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入時自動啟動 RunCat"
           }
         }
       }
     },
-    "onlyMonochromeRunners": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nur aus einfarbigen Läufern wählen"
+    "onlyMonochromeRunners" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur aus einfarbigen Läufern wählen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select from only monochrome runners"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select from only monochrome runners"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélectionne seulement les coureurs monochrome"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionne seulement les coureurs monochrome"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "モノクロのランナーのみから選択する"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モノクロのランナーのみから選択する"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "흑백 러너중에서 선택"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "흑백 러너중에서 선택"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仅单色跑者"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅单色跑者"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選擇僅單色跑者"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccionar solo de corredores monocromáticos"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇僅單色跑者"
           }
         }
       }
     },
-    "runner": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Läufer"
+    "runner" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Läufer"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Runner"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Runner"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coureur"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coureur"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ランナー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ランナー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "러너"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "러너"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "跑者"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跑者"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "跑者"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Corredor"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跑者"
           }
         }
       }
     },
-    "selectAutomatically": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle 10 Minuten automatisch zufällig auswählen"
+    "selectAutomatically" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle 10 Minuten automatisch zufällig auswählen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select randomly per 10 minutes automatically"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select randomly per 10 minutes automatically"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sélection aléatoire toutes les 10 minutes"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélection aléatoire toutes les 10 minutes"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10分ごとにランダムで自動選択"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10分ごとにランダムで自動選択"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10분마다 랜덤하게 러너 바꾸기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10분마다 랜덤하게 러너 바꾸기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "每 10 分钟随机一个"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每 10 分钟随机一个"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "每 10 分鐘隨機選擇"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seleccionar aleatoriamente cada 10 minutos automáticamente"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每 10 分鐘隨機選擇"
           }
         }
       }
     },
-    "stop": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Läufer anhalten"
+    "stop" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Läufer anhalten"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop the runner"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop the runner"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arrêter le coureur"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrêter le coureur"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "停止する"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止する"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "러너 멈추기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "러너 멈추기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "停止"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "停止跑者"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detener el corredor"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止跑者"
           }
         }
       }
     },
-    "stopRunner": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Läufer anhalten"
+    "stopRunner" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Läufer anhalten"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop the runner"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop the runner"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arrêter le coureur"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrêter le coureur"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ランナーを停止"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ランナーを停止"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "러너를 멈춰주세요"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "러너를 멈춰주세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "停止跑者"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止跑者"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "停止跑者"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detener el corredor"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止跑者"
           }
         }
       }
     },
-    "stopRunnerMessage": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wenn Du den Läufer anhälst, geht die Einzigartigkeit dieser Anwendung verloren."
+    "stopRunnerMessage" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn Du den Läufer anhälst, geht die Einzigartigkeit dieser Anwendung verloren."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If you stop the runner, the uniqueness of this application will be lost."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If you stop the runner, the uniqueness of this application will be lost."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si vous arrêter les mouvements du coureur, le caractère unique de l’application sera perdu."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si vous arrêter les mouvements du coureur, le caractère unique de l’application sera perdu."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ランナーを停止してしまうと本アプリの独自性が失われます。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ランナーを停止してしまうと本アプリの独自性が失われます。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "만약 러너를 멈춘다면, 이 애플리케이션의 특징을 잃게됩니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "만약 러너를 멈춘다면, 이 애플리케이션의 특징을 잃게됩니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "如果停止跑者，就会失去软件的趣味性"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果停止跑者，就会失去软件的趣味性"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "如果你停止了跑者，就會失去此 App 的獨特性"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si detienes el corredor, se perderá la singularidad de esta aplicación."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果你停止了跑者，就會失去此 App 的獨特性"
           }
         }
       }
     },
-    "stopRunnerTitle": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Möchtest Du den Läufer wirklich anhalten?"
+    "stopRunnerTitle" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Möchtest Du den Läufer wirklich anhalten?"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Do you really want to stop the runner?"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Do you really want to stop the runner?"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voulez-vous vraiment arrêter les mouvements du coureur ?"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment arrêter les mouvements du coureur ?"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本当にランナーを停止しても良いですか？"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本当にランナーを停止しても良いですか？"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "정말로 러너를 멈추시겠습니까?"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정말로 러너를 멈추시겠습니까?"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "你确定要停止跑者吗？"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你确定要停止跑者吗？"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "你確定要停止跑者嗎？"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "¿Realmente quieres detener el corredor?"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你確定要停止跑者嗎？"
           }
         }
       }
     },
-    "useAccentColor": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verwende die Akzentfarbe des Systems"
+    "useAccentColor" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwende die Akzentfarbe des Systems"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use the system accent color"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use the system accent color"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utiliser la couleur d’accentuation du système"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utiliser la couleur d’accentuation du système"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "システムのアクセントカラーを使用"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システムのアクセントカラーを使用"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "시스템 강조 색상 사용"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시스템 강조 색상 사용"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用系统强调色"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用系统强调色"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用系統主題色"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usar el color de acento del sistema"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用系統主題色"
           }
         }
       }
     }
   },
-  "version": "1.0"
+  "version" : "1.0"
 }

--- a/Sources/RunCatLocalization/Resources/GeneralSettings.xcstrings
+++ b/Sources/RunCatLocalization/Resources/GeneralSettings.xcstrings
@@ -44,6 +44,12 @@
             "state" : "translated",
             "value" : "選擇所有跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar entre todos los corredores"
+          }
         }
       }
     },
@@ -89,6 +95,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "我改變主意了"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambié de opinión"
           }
         }
       }
@@ -136,6 +148,12 @@
             "state" : "translated",
             "value" : "水平翻轉"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voltear horizontalmente"
+          }
         }
       }
     },
@@ -181,6 +199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "速度反轉"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invertir velocidad"
           }
         }
       }
@@ -228,6 +252,12 @@
             "state" : "translated",
             "value" : "啟動"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar"
+          }
         }
       }
     },
@@ -273,6 +303,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登入時自動啟動 RunCat"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar RunCat automáticamente al iniciar sesión."
           }
         }
       }
@@ -320,6 +356,12 @@
             "state" : "translated",
             "value" : "選擇僅單色跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar corredores monocromáticos"
+          }
         }
       }
     },
@@ -365,6 +407,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredor"
           }
         }
       }
@@ -412,6 +460,12 @@
             "state" : "translated",
             "value" : "每 10 分鐘隨機選擇"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar aleatoriamente cada 10 minutos automáticamente"
+          }
         }
       }
     },
@@ -457,6 +511,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "停止跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detener el corredor"
           }
         }
       }
@@ -504,6 +564,12 @@
             "state" : "translated",
             "value" : "停止跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detener el corredor"
+          }
         }
       }
     },
@@ -549,6 +615,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "如果你停止了跑者，就會失去此 App 的獨特性"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si detienes el corredor, se perderá la singularidad de esta aplicación."
           }
         }
       }
@@ -596,6 +668,12 @@
             "state" : "translated",
             "value" : "你確定要停止跑者嗎？"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Realmente quieres detener el corredor?"
+          }
         }
       }
     },
@@ -641,6 +719,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用系統主題色"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usar el color del sistema"
           }
         }
       }

--- a/Sources/RunCatLocalization/Resources/Others.xcstrings
+++ b/Sources/RunCatLocalization/Resources/Others.xcstrings
@@ -1,835 +1,943 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "%@queryLang" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@?lang=de"
+  "sourceLanguage": "en",
+  "strings": {
+    "%@queryLang": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@?lang=de"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@?lang=en"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@?lang=en"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@?lang=fr"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@?lang=fr"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@?lang=ja"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@?lang=ja"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@?lang=ko"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@?lang=ko"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@?lang=zh-Hans"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@?lang=zh-Hans"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@?lang=zh-Hant"
-          }
-        }
-      }
-    },
-    "endlessGameTitle" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Endlosspiel"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@?lang=zh-Hant"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Endless Game"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jeu infini"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エンドレスゲーム"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "엔드리스 게임"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无尽游戏"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無盡遊戲"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@?lang=en"
           }
         }
       }
     },
-    "generalTab" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allgemein"
+    "endlessGameTitle": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Endlosspiel"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Endless Game"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Général"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jeu infini"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一般"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エンドレスゲーム"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "일반"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "엔드리스 게임"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "常规"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无尽游戏"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一般"
-          }
-        }
-      }
-    },
-    "localization" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Übersetzung"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無盡遊戲"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Localization"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Localisation"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ローカリゼーション"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "현지화"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "本地化"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "本地化"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Endless Game"
           }
         }
       }
     },
-    "mailEnvironment%@%@%@%@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Umgebung\n- %@: ver %@\n- %@\n- macOS: %@"
+    "generalTab": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allgemein"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Environment\n- %@: ver %@\n- %@\n- macOS: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Environnement\n- %@ : ver %@\n- %@\n- macOS: %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Général"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 環境\n- %@：ver %@\n- %@\n- macOS：%@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 실행환경\n- %@: ver %@\n- %@\n- macOS: %@"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 环境\n- %@：ver %@\n- %@\n- macOS：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常规"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 環境\n- %@：ver %@\n- %@\n- macOS：%@"
-          }
-        }
-      }
-    },
-    "mailExpectedResult" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Erwartetes Verhalten"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Expected Result"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Résultat attendu"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 本来期待される挙動"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 기대한 결과"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 预期的结果"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 預期結果"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         }
       }
     },
-    "mailIssueReport%@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ Fehler gemeldet "
+    "localization": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Übersetzung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ Issue Report"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Localization"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ Rapporter un problème"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Localisation"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 不具合の報告"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ローカリゼーション"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 문제점 알리기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현지화"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 报告问题"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地化"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 報告問題"
-          }
-        }
-      }
-    },
-    "mailReproduceIssue" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Schritte um den Fehler zu reproduzieren"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本地化"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Steps to Reproduce the Issue"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Étapes pour reproduire le problème"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 不具合の再現手順（不具合が発生した際に行なっていた操作）"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 문제가 발생하기까지 조작한 순서"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 重现步骤"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 重現問題的步驟"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Localización"
           }
         }
       }
     },
-    "mailShortDescription" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Kurzbeschreibung"
+    "mailEnvironment%@%@%@%@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Umgebung\n- %@: ver %@\n- %@\n- macOS: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Short Description"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Environment\n- %@: ver %@\n- %@\n- macOS: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Courte description"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Environnement\n- %@ : ver %@\n- %@\n- macOS: %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 不具合の簡単な説明"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 環境\n- %@：ver %@\n- %@\n- macOS：%@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 문제점에 대한 간단한 설명"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 실행환경\n- %@: ver %@\n- %@\n- macOS: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 简要描述"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 环境\n- %@：ver %@\n- %@\n- macOS：%@"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 間單的描述"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 環境\n- %@：ver %@\n- %@\n- macOS：%@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Environment\n- %@: ver %@\n- %@\n- macOS: %@"
           }
         }
       }
     },
-    "mailWhatYouTried" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Was hast du probiert\n- Neustart der app: Ja/Nein\n- Läufer Store wiederhergestellt: Ja/Nein\n- App deinstalliert: Ja/Nein"
+    "mailExpectedResult": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Erwartetes Verhalten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# What You Tried\n- Relaunched the app: Yes/No\n- Restored at Runners Store: Yes/No\n- Uninstalled the app: Yes/No"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Expected Result"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# Qu’essayez-vous de faire\n- Relancer l’app : Oui/Non\n- Restaurer dans le Magasin de Coureurs : Oui/Non\n- Désinstaller l’app : Oui/Non"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Résultat attendu"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 試したこと\n- アプリの再起動：はい/いいえ\n- ランナーストアにて購入の復元：はい/いいえ\n- アプリのアンインストール：はい/いいえ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 本来期待される挙動"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 아래의 내용을 확인해주세요\n- 앱을 재실행 했습니다: 예/아니오\n- 러너 스토어에서 복구를 시도했습니다: 예/아니오\n- 앱을 제거 했습니다:  예/아니오"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 기대한 결과"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 尝试过的操作\n- 重启软件：是/否\n- 从跑者商店恢复: 是/否\n- 卸载软件：是/否"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 预期的结果"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "# 嘗試過的操作\n- 重新啟動 App：是/否\n- 從跑者商店還原：是/否\n- 解除安裝 App：是/否"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 預期結果"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Expected Result"
           }
         }
       }
     },
-    "support" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Support-Seite"
+    "mailIssueReport%@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Fehler gemeldet "
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Support Page"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Issue Report"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Web pour l’assistance"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Rapporter un problème"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サポートページ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 不具合の報告"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "서포트 페이지"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 문제점 알리기"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "支持页面"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 报告问题"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "支援頁面"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 報告問題"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Issue Report"
           }
         }
       }
     },
-    "systemInfoTab" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System Info"
+    "mailReproduceIssue": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Schritte um den Fehler zu reproduzieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System Info"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Steps to Reproduce the Issue"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Infos système"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Étapes pour reproduire le problème"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システム情報"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 不具合の再現手順（不具合が発生した際に行なっていた操作）"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "시스템 정보"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 문제가 발생하기까지 조작한 순서"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系统信息"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 重现步骤"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系統資訊"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 重現問題的步驟"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Steps to Reproduce the Issue"
           }
         }
       }
     },
-    "translatorChineseSimplified" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vereinfachtes Chinesisch - Junjie Lin (junzilla)"
+    "mailShortDescription": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Kurzbeschreibung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chinese, Simplified - Junjie Lin (junzilla)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Short Description"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chinois Simplifié - Junjie Lin (junzilla)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Courte description"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "中国語 (簡体) - Junjie Lin (junzilla)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 不具合の簡単な説明"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중국어 (간체) - Junjie Lin (junzilla)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 문제점에 대한 간단한 설명"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "简体中文 - Junjie Lin (junzilla)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 简要描述"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "簡體中文 - Junjie Lin (junzilla)"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 間單的描述"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Short Description"
           }
         }
       }
     },
-    "translatorChineseTraditional" : {
-      "generatesSymbol" : false,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Traditionelles Chinesisch - Qing Bi Liao (Pencil126)"
+    "mailWhatYouTried": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Was hast du probiert\n- Neustart der app: Ja/Nein\n- Läufer Store wiederhergestellt: Ja/Nein\n- App deinstalliert: Ja/Nein"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chinese, Traditional - Qing Bi Liao (Pencil126)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# What You Tried\n- Relaunched the app: Yes/No\n- Restored at Runners Store: Yes/No\n- Uninstalled the app: Yes/No"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chinois traditionnel - Qing Bi Liao (Pencil126)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# Qu’essayez-vous de faire\n- Relancer l’app : Oui/Non\n- Restaurer dans le Magasin de Coureurs : Oui/Non\n- Désinstaller l’app : Oui/Non"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "中国語 (繁体) - Qing Bi Liao (Pencil126)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 試したこと\n- アプリの再起動：はい/いいえ\n- ランナーストアにて購入の復元：はい/いいえ\n- アプリのアンインストール：はい/いいえ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중국어 (번체) - Qing Bi Liao (Pencil126)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 아래의 내용을 확인해주세요\n- 앱을 재실행 했습니다: 예/아니오\n- 러너 스토어에서 복구를 시도했습니다: 예/아니오\n- 앱을 제거 했습니다:  예/아니오"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "繁体中文 - Qing Bi Liao (Pencil126)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 尝试过的操作\n- 重启软件：是/否\n- 从跑者商店恢复: 是/否\n- 卸载软件：是/否"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "繁體中文 - Qing Bi Liao (Pencil126)"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# 嘗試過的操作\n- 重新啟動 App：是/否\n- 從跑者商店還原：是/否\n- 解除安裝 App：是/否"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "# What You Tried\n- Relaunched the app: Yes/No\n- Restored at Corredors Store: Yes/No\n- Uninstalled the app: Yes/No"
           }
         }
       }
     },
-    "translatorFrench" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Französisch - Kravatox"
+    "support": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support-Seite"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "French - Kravatox"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support Page"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Français - Kravatox"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Page Web pour l’assistance"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フランス語 - Kravatox"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サポートページ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "프랑스어 - Kravatox"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서포트 페이지"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "法语 - Kravatox"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支持页面"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "法語 - Kravatox"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支援頁面"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Página de soporte"
           }
         }
       }
     },
-    "translatorGerman" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deutsch - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+    "systemInfoTab": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Info"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "German - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Info"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allemand - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Infos système"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ドイツ語 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム情報"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "독일어 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 정보"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "德语 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统信息"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "德語 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系統資訊"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Información del sistema"
           }
         }
       }
     },
-    "translatorJapanese" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Japanisch - Takuto Nakamura (Kyome)"
+    "translatorChineseSimplified": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vereinfachtes Chinesisch - Junjie Lin (junzilla)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Japanese - Takuto Nakamura (Kyome)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chinese, Simplified - Junjie Lin (junzilla)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Japonais - Takuto Nakamura (Kyome)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chinois Simplifié - Junjie Lin (junzilla)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日本語 - Takuto Nakamura (Kyome)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中国語 (簡体) - Junjie Lin (junzilla)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "일본어 - Takuto Nakamura (Kyome)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중국어 (간체) - Junjie Lin (junzilla)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日语 - Takuto Nakamura (Kyome)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文 - Junjie Lin (junzilla)"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日語 - Takuto Nakamura (Kyome)"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "簡體中文 - Junjie Lin (junzilla)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chinese, Simplified - Junjie Lin (junzilla)"
           }
         }
       }
     },
-    "translatorKorean" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Koreanisch - Jaewon Gwon (Jake)"
+    "translatorChineseTraditional": {
+      "generatesSymbol": false,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traditionelles Chinesisch - Qing Bi Liao (Pencil126)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Korean - Jaewon Gwon (Jake)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chinese, Traditional - Qing Bi Liao (Pencil126)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coréen - Jaewon Gwon (Jake)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chinois traditionnel - Qing Bi Liao (Pencil126)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "韓国語 - Jaewon Gwon (Jake)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中国語 (繁体) - Qing Bi Liao (Pencil126)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "한국어 - Jaewon Gwon (Jake)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중국어 (번체) - Qing Bi Liao (Pencil126)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "韩语 - Jaewon Gwon (Jake)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繁体中文 - Qing Bi Liao (Pencil126)"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "韓語 - Jaewon Gwon (Jake)"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繁體中文 - Qing Bi Liao (Pencil126)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chinese, Traditional - Qing Bi Liao (Pencil126)"
+          }
+        }
+      }
+    },
+    "translatorFrench": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Französisch - Kravatox"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "French - Kravatox"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français - Kravatox"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フランス語 - Kravatox"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프랑스어 - Kravatox"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "法语 - Kravatox"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "法語 - Kravatox"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "French - Kravatox"
+          }
+        }
+      }
+    },
+    "translatorGerman": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "German - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allemand - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドイツ語 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "독일어 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "德语 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "德語 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "German - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+          }
+        }
+      }
+    },
+    "translatorJapanese": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japanisch - Takuto Nakamura (Kyome)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japanese - Takuto Nakamura (Kyome)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japonais - Takuto Nakamura (Kyome)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語 - Takuto Nakamura (Kyome)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일본어 - Takuto Nakamura (Kyome)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日语 - Takuto Nakamura (Kyome)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日語 - Takuto Nakamura (Kyome)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japanese - Takuto Nakamura (Kyome)"
+          }
+        }
+      }
+    },
+    "translatorKorean": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koreanisch - Jaewon Gwon (Jake)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korean - Jaewon Gwon (Jake)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coréen - Jaewon Gwon (Jake)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "韓国語 - Jaewon Gwon (Jake)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한국어 - Jaewon Gwon (Jake)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "韩语 - Jaewon Gwon (Jake)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "韓語 - Jaewon Gwon (Jake)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korean - Jaewon Gwon (Jake)"
           }
         }
       }
     }
   },
-  "version" : "1.1"
+  "version": "1.1"
 }

--- a/Sources/RunCatLocalization/Resources/Others.xcstrings
+++ b/Sources/RunCatLocalization/Resources/Others.xcstrings
@@ -44,6 +44,12 @@
             "state" : "translated",
             "value" : "%@?lang=zh-Hant"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@?lang=es"
+          }
         }
       }
     },
@@ -89,6 +95,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無盡遊戲"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Juego infinito"
           }
         }
       }
@@ -136,6 +148,12 @@
             "state" : "translated",
             "value" : "一般"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
         }
       }
     },
@@ -181,6 +199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "本地化"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Localización"
           }
         }
       }
@@ -228,6 +252,12 @@
             "state" : "translated",
             "value" : "# 環境\n- %@：ver %@\n- %@\n- macOS：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Entorno\n- %@: ver %@\n- %@\n- macOS: %@"
+          }
         }
       }
     },
@@ -273,6 +303,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "# 預期結果"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Resultado esperado"
           }
         }
       }
@@ -320,6 +356,12 @@
             "state" : "translated",
             "value" : "%@ 報告問題"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ Reporte de problema"
+          }
         }
       }
     },
@@ -365,6 +407,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "# 重現問題的步驟"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Pasos para reproducir el problema"
           }
         }
       }
@@ -412,6 +460,12 @@
             "state" : "translated",
             "value" : "# 間單的描述"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Descripción breve"
+          }
         }
       }
     },
@@ -457,6 +511,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "# 嘗試過的操作\n- 重新啟動 App：是/否\n- 從跑者商店還原：是/否\n- 解除安裝 App：是/否"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Lo que intentaste\n- Reiniciaste la app: Sí/No\n- Restauraste en Tienda de Corredores: Sí/No\n- Desinstalaste la app: Sí/No"
           }
         }
       }
@@ -504,6 +564,12 @@
             "state" : "translated",
             "value" : "支援頁面"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Página de soporte"
+          }
         }
       }
     },
@@ -550,6 +616,12 @@
             "state" : "translated",
             "value" : "系統資訊"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Información del sistema"
+          }
         }
       }
     },
@@ -595,6 +667,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "簡體中文 - Junjie Lin (junzilla)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chino simplificado - Junjie Lin (junzilla)"
           }
         }
       }
@@ -643,6 +721,12 @@
             "state" : "translated",
             "value" : "繁體中文 - Qing Bi Liao (Pencil126)"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chino tradicional - Qing Bi Liao (Pencil126)"
+          }
         }
       }
     },
@@ -688,6 +772,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "法語 - Kravatox"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Francés - Kravatox"
           }
         }
       }
@@ -735,6 +825,12 @@
             "state" : "translated",
             "value" : "德語 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alemán - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+          }
         }
       }
     },
@@ -781,6 +877,12 @@
             "state" : "translated",
             "value" : "日語 - Takuto Nakamura (Kyome)"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Japonés - Takuto Nakamura (Kyome)"
+          }
         }
       }
     },
@@ -826,6 +928,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "韓語 - Jaewon Gwon (Jake)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coreano - Jaewon Gwon (Jake)"
           }
         }
       }

--- a/Sources/RunCatLocalization/Resources/Others.xcstrings
+++ b/Sources/RunCatLocalization/Resources/Others.xcstrings
@@ -1,943 +1,835 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "%@queryLang": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@?lang=de"
+  "sourceLanguage" : "en",
+  "strings" : {
+    "%@queryLang" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@?lang=de"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@?lang=en"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@?lang=en"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@?lang=fr"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@?lang=fr"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@?lang=ja"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@?lang=ja"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@?lang=ko"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@?lang=ko"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@?lang=zh-Hans"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@?lang=zh-Hans"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@?lang=zh-Hant"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@?lang=en"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@?lang=zh-Hant"
           }
         }
       }
     },
-    "endlessGameTitle": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Endlosspiel"
+    "endlessGameTitle" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Endlosspiel"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Endless Game"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Endless Game"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jeu infini"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeu infini"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エンドレスゲーム"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エンドレスゲーム"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "엔드리스 게임"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "엔드리스 게임"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无尽游戏"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无尽游戏"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "無盡遊戲"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Endless Game"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無盡遊戲"
           }
         }
       }
     },
-    "generalTab": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allgemein"
+    "generalTab" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allgemein"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "General"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Général"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Général"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一般"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "일반"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일반"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "常规"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常规"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一般"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "General"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
           }
         }
       }
     },
-    "localization": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Übersetzung"
+    "localization" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Übersetzung"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Localization"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Localization"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Localisation"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Localisation"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ローカリゼーション"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ローカリゼーション"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "현지화"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현지화"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本地化"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地化"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本地化"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Localización"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地化"
           }
         }
       }
     },
-    "mailEnvironment%@%@%@%@": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Umgebung\n- %@: ver %@\n- %@\n- macOS: %@"
+    "mailEnvironment%@%@%@%@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Umgebung\n- %@: ver %@\n- %@\n- macOS: %@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Environment\n- %@: ver %@\n- %@\n- macOS: %@"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Environment\n- %@: ver %@\n- %@\n- macOS: %@"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Environnement\n- %@ : ver %@\n- %@\n- macOS: %@"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Environnement\n- %@ : ver %@\n- %@\n- macOS: %@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 環境\n- %@：ver %@\n- %@\n- macOS：%@"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 環境\n- %@：ver %@\n- %@\n- macOS：%@"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 실행환경\n- %@: ver %@\n- %@\n- macOS: %@"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 실행환경\n- %@: ver %@\n- %@\n- macOS: %@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 环境\n- %@：ver %@\n- %@\n- macOS：%@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 环境\n- %@：ver %@\n- %@\n- macOS：%@"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 環境\n- %@：ver %@\n- %@\n- macOS：%@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Environment\n- %@: ver %@\n- %@\n- macOS: %@"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 環境\n- %@：ver %@\n- %@\n- macOS：%@"
           }
         }
       }
     },
-    "mailExpectedResult": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Erwartetes Verhalten"
+    "mailExpectedResult" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Erwartetes Verhalten"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Expected Result"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Expected Result"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Résultat attendu"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Résultat attendu"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 本来期待される挙動"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 本来期待される挙動"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 기대한 결과"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 기대한 결과"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 预期的结果"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 预期的结果"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 預期結果"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Expected Result"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 預期結果"
           }
         }
       }
     },
-    "mailIssueReport%@": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ Fehler gemeldet "
+    "mailIssueReport%@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ Fehler gemeldet "
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ Issue Report"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ Issue Report"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ Rapporter un problème"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ Rapporter un problème"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 不具合の報告"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 不具合の報告"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 문제점 알리기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 문제점 알리기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 报告问题"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 报告问题"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 報告問題"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ Issue Report"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 報告問題"
           }
         }
       }
     },
-    "mailReproduceIssue": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Schritte um den Fehler zu reproduzieren"
+    "mailReproduceIssue" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Schritte um den Fehler zu reproduzieren"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Steps to Reproduce the Issue"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Steps to Reproduce the Issue"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Étapes pour reproduire le problème"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Étapes pour reproduire le problème"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 不具合の再現手順（不具合が発生した際に行なっていた操作）"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 不具合の再現手順（不具合が発生した際に行なっていた操作）"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 문제가 발생하기까지 조작한 순서"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 문제가 발생하기까지 조작한 순서"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 重现步骤"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 重现步骤"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 重現問題的步驟"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Steps to Reproduce the Issue"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 重現問題的步驟"
           }
         }
       }
     },
-    "mailShortDescription": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Kurzbeschreibung"
+    "mailShortDescription" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Kurzbeschreibung"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Short Description"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Short Description"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Courte description"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Courte description"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 不具合の簡単な説明"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 不具合の簡単な説明"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 문제점에 대한 간단한 설명"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 문제점에 대한 간단한 설명"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 简要描述"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 简要描述"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 間單的描述"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Short Description"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 間單的描述"
           }
         }
       }
     },
-    "mailWhatYouTried": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Was hast du probiert\n- Neustart der app: Ja/Nein\n- Läufer Store wiederhergestellt: Ja/Nein\n- App deinstalliert: Ja/Nein"
+    "mailWhatYouTried" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Was hast du probiert\n- Neustart der app: Ja/Nein\n- Läufer Store wiederhergestellt: Ja/Nein\n- App deinstalliert: Ja/Nein"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# What You Tried\n- Relaunched the app: Yes/No\n- Restored at Runners Store: Yes/No\n- Uninstalled the app: Yes/No"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# What You Tried\n- Relaunched the app: Yes/No\n- Restored at Runners Store: Yes/No\n- Uninstalled the app: Yes/No"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# Qu’essayez-vous de faire\n- Relancer l’app : Oui/Non\n- Restaurer dans le Magasin de Coureurs : Oui/Non\n- Désinstaller l’app : Oui/Non"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Qu’essayez-vous de faire\n- Relancer l’app : Oui/Non\n- Restaurer dans le Magasin de Coureurs : Oui/Non\n- Désinstaller l’app : Oui/Non"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 試したこと\n- アプリの再起動：はい/いいえ\n- ランナーストアにて購入の復元：はい/いいえ\n- アプリのアンインストール：はい/いいえ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 試したこと\n- アプリの再起動：はい/いいえ\n- ランナーストアにて購入の復元：はい/いいえ\n- アプリのアンインストール：はい/いいえ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 아래의 내용을 확인해주세요\n- 앱을 재실행 했습니다: 예/아니오\n- 러너 스토어에서 복구를 시도했습니다: 예/아니오\n- 앱을 제거 했습니다:  예/아니오"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 아래의 내용을 확인해주세요\n- 앱을 재실행 했습니다: 예/아니오\n- 러너 스토어에서 복구를 시도했습니다: 예/아니오\n- 앱을 제거 했습니다:  예/아니오"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 尝试过的操作\n- 重启软件：是/否\n- 从跑者商店恢复: 是/否\n- 卸载软件：是/否"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 尝试过的操作\n- 重启软件：是/否\n- 从跑者商店恢复: 是/否\n- 卸载软件：是/否"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# 嘗試過的操作\n- 重新啟動 App：是/否\n- 從跑者商店還原：是/否\n- 解除安裝 App：是/否"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "# What You Tried\n- Relaunched the app: Yes/No\n- Restored at Corredors Store: Yes/No\n- Uninstalled the app: Yes/No"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# 嘗試過的操作\n- 重新啟動 App：是/否\n- 從跑者商店還原：是/否\n- 解除安裝 App：是/否"
           }
         }
       }
     },
-    "support": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Support-Seite"
+    "support" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Support-Seite"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Support Page"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Support Page"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Page Web pour l’assistance"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Web pour l’assistance"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サポートページ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サポートページ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "서포트 페이지"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "서포트 페이지"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "支持页面"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支持页面"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "支援頁面"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Página de soporte"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支援頁面"
           }
         }
       }
     },
-    "systemInfoTab": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "System Info"
+    "systemInfoTab" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System Info"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "System Info"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System Info"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Infos système"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Infos système"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "システム情報"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム情報"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "시스템 정보"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시스템 정보"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "系统信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统信息"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "系統資訊"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Información del sistema"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統資訊"
           }
         }
       }
     },
-    "translatorChineseSimplified": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vereinfachtes Chinesisch - Junjie Lin (junzilla)"
+    "translatorChineseSimplified" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vereinfachtes Chinesisch - Junjie Lin (junzilla)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chinese, Simplified - Junjie Lin (junzilla)"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chinese, Simplified - Junjie Lin (junzilla)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chinois Simplifié - Junjie Lin (junzilla)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chinois Simplifié - Junjie Lin (junzilla)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中国語 (簡体) - Junjie Lin (junzilla)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中国語 (簡体) - Junjie Lin (junzilla)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "중국어 (간체) - Junjie Lin (junzilla)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중국어 (간체) - Junjie Lin (junzilla)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "简体中文 - Junjie Lin (junzilla)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "简体中文 - Junjie Lin (junzilla)"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "簡體中文 - Junjie Lin (junzilla)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chinese, Simplified - Junjie Lin (junzilla)"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "簡體中文 - Junjie Lin (junzilla)"
           }
         }
       }
     },
-    "translatorChineseTraditional": {
-      "generatesSymbol": false,
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Traditionelles Chinesisch - Qing Bi Liao (Pencil126)"
+    "translatorChineseTraditional" : {
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traditionelles Chinesisch - Qing Bi Liao (Pencil126)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chinese, Traditional - Qing Bi Liao (Pencil126)"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chinese, Traditional - Qing Bi Liao (Pencil126)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chinois traditionnel - Qing Bi Liao (Pencil126)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chinois traditionnel - Qing Bi Liao (Pencil126)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中国語 (繁体) - Qing Bi Liao (Pencil126)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中国語 (繁体) - Qing Bi Liao (Pencil126)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "중국어 (번체) - Qing Bi Liao (Pencil126)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중국어 (번체) - Qing Bi Liao (Pencil126)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "繁体中文 - Qing Bi Liao (Pencil126)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繁体中文 - Qing Bi Liao (Pencil126)"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "繁體中文 - Qing Bi Liao (Pencil126)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chinese, Traditional - Qing Bi Liao (Pencil126)"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繁體中文 - Qing Bi Liao (Pencil126)"
           }
         }
       }
     },
-    "translatorFrench": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Französisch - Kravatox"
+    "translatorFrench" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Französisch - Kravatox"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "French - Kravatox"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "French - Kravatox"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Français - Kravatox"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Français - Kravatox"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フランス語 - Kravatox"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フランス語 - Kravatox"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "프랑스어 - Kravatox"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "프랑스어 - Kravatox"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "法语 - Kravatox"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "法语 - Kravatox"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "法語 - Kravatox"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "French - Kravatox"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "法語 - Kravatox"
           }
         }
       }
     },
-    "translatorGerman": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deutsch - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+    "translatorGerman" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deutsch - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "German - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "German - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allemand - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allemand - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ドイツ語 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドイツ語 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "독일어 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "독일어 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "德语 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "德语 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "德語 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "German - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "德語 - Marius Schröder (schroedermarius), Sebastian Jensen (tsjdev-apps)"
           }
         }
       }
     },
-    "translatorJapanese": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Japanisch - Takuto Nakamura (Kyome)"
+    "translatorJapanese" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Japanisch - Takuto Nakamura (Kyome)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Japanese - Takuto Nakamura (Kyome)"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Japanese - Takuto Nakamura (Kyome)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Japonais - Takuto Nakamura (Kyome)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Japonais - Takuto Nakamura (Kyome)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日本語 - Takuto Nakamura (Kyome)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日本語 - Takuto Nakamura (Kyome)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "일본어 - Takuto Nakamura (Kyome)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일본어 - Takuto Nakamura (Kyome)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日语 - Takuto Nakamura (Kyome)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日语 - Takuto Nakamura (Kyome)"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日語 - Takuto Nakamura (Kyome)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Japanese - Takuto Nakamura (Kyome)"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日語 - Takuto Nakamura (Kyome)"
           }
         }
       }
     },
-    "translatorKorean": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Koreanisch - Jaewon Gwon (Jake)"
+    "translatorKorean" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koreanisch - Jaewon Gwon (Jake)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Korean - Jaewon Gwon (Jake)"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Korean - Jaewon Gwon (Jake)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coréen - Jaewon Gwon (Jake)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coréen - Jaewon Gwon (Jake)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "韓国語 - Jaewon Gwon (Jake)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "韓国語 - Jaewon Gwon (Jake)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "한국어 - Jaewon Gwon (Jake)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "한국어 - Jaewon Gwon (Jake)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "韩语 - Jaewon Gwon (Jake)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "韩语 - Jaewon Gwon (Jake)"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "韓語 - Jaewon Gwon (Jake)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Korean - Jaewon Gwon (Jake)"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "韓語 - Jaewon Gwon (Jake)"
           }
         }
       }
     }
   },
-  "version": "1.1"
+  "version" : "1.1"
 }

--- a/Sources/RunCatLocalization/Resources/RunnerName.xcstrings
+++ b/Sources/RunCatLocalization/Resources/RunnerName.xcstrings
@@ -516,7 +516,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Imitación de Nyan Cat."
+            "value" : "Imitación de Nyan Cat"
           }
         }
       }

--- a/Sources/RunCatLocalization/Resources/RunnerName.xcstrings
+++ b/Sources/RunCatLocalization/Resources/RunnerName.xcstrings
@@ -1,3686 +1,4166 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "b_cat" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Katze β"
+  "sourceLanguage": "en",
+  "strings": {
+    "b_cat": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Katze β"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cat β"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cat β"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chat β"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chat β"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ネコ β"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネコ β"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "베타냥"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "베타냥"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "β 猫"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "β 猫"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "β 貓"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "β 貓"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cat β"
+          }
         }
       }
     },
-    "bird" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vogel"
+    "bird": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vogel"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bird"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bird"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oiseau"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oiseau"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "トリ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トリ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "새"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "小鸟"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小鸟"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "小鳥"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小鳥"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bird"
+          }
         }
       }
     },
-    "bonfire" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lagerfeuer"
+    "bonfire": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lagerfeuer"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonfire"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bonfire"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feu de camp"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feu de camp"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "焚き火"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "焚き火"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모닥불"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "모닥불"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "篝火"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "篝火"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "營火"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "營火"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonfire"
           }
         }
       }
     },
-    "butterfly" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schmetterling"
+    "butterfly": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schmetterling"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Butterfly"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Butterfly"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Papillon"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Papillon"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "蝶々"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "蝶々"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "나비"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "나비"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "蝴蝶"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "蝴蝶"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "蝴蝶"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "蝴蝶"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Butterfly"
           }
         }
       }
     },
-    "c_cat" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Katze γ"
+    "c_cat": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Katze γ"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cat γ"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cat γ"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chat γ"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chat γ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネコ γ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ネコ γ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "감마냥"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "감마냥"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "γ 猫"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "γ 猫"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "γ 貓"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "γ 貓"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cat γ"
           }
         }
       }
     },
-    "cat" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Katze α"
+    "cat": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Katze α"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cat α"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cat α"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chat α"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chat α"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ネコ α"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネコ α"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "알파냥"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알파냥"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "α 猫"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "α 猫"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "α 貓"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "α 貓"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cat α"
+          }
         }
       }
     },
-    "cat_cluster_metal" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metallcluster-Katze"
+    "cat_cluster_metal": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metallcluster-Katze"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metal Cluster Cat"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal Cluster Cat"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chat Métal Cluster"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chat Métal Cluster"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メタルクラスタキャット"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メタルクラスタキャット"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메탈냥"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메탈냥"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "金属团猫"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "金属团猫"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "金屬簇貓"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "金屬簇貓"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metal Cluster Cat"
+          }
         }
       }
     },
-    "cat_flash" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flash-Katze"
+    "cat_flash": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flash-Katze"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flash Cat"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Flash Cat"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chat Flash"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chat Flash"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "赤い閃光猫"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "赤い閃光猫"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "플래시냥"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "플래시냥"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "闪电猫"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "闪电猫"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閃電貓"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "閃電貓"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flash Cat"
           }
         }
       }
     },
-    "cat_golden" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Goldene Katze"
+    "cat_golden": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Goldene Katze"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Golden Cat"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Golden Cat"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chat doré"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chat doré"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "黄金のネコ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "黄金のネコ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "골든냥"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "골든냥"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "金猫"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "金猫"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "黃金貓"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "黃金貓"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Golden Cat"
           }
         }
       }
     },
-    "cat_nyan_mock" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mock Nyan Cat"
+    "cat_nyan_mock": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mock Nyan Cat"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mock Nyan Cat"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mock Nyan Cat"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réplique Nyan Cat"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réplique Nyan Cat"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nyan Catもどき"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nyan Catもどき"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "디스크 냥캣"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "디스크 냥캣"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "模仿彩虹猫"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "模仿彩虹猫"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仿彩虹貓"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "仿彩虹貓"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mock Nyan Cat"
           }
         }
       }
     },
-    "chameleon" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chamäleon"
+    "chameleon": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chamäleon"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chameleon"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chameleon"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caméléon"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caméléon"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "カメレオン"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カメレオン"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "카멜레온"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "카멜레온"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "变色龙"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "变色龙"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "變色龍"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "變色龍"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chameleon"
+          }
         }
       }
     },
-    "cheetah" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gepard"
+    "cheetah": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gepard"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cheetah"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cheetah"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guépard"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guépard"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "チーター"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チーター"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "치타"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "치타"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "猎豹"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "猎豹"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "獵豹"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "獵豹"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cheetah"
+          }
         }
       }
     },
-    "chicken" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Huhn"
+    "chicken": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huhn"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chicken"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chicken"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poule"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poule"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ニワトリ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ニワトリ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "닭"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "닭"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小鸡"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "小鸡"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小雞"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "小雞"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chicken"
           }
         }
       }
     },
-    "chime_wind" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windspiel"
+    "chime_wind": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windspiel"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wind Chime"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wind Chime"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carillon à vent"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Carillon à vent"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "風鈴"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "風鈴"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "풍경"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "풍경"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "风铃"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "风铃"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "風鈴"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "風鈴"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wind Chime"
           }
         }
       }
     },
-    "city" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stadt"
+    "city": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stadt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "City"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "City"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ville"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ville"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "都会"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "都会"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도시"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "도시"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "城市"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "城市"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "城市"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "城市"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "City"
           }
         }
       }
     },
-    "coffee" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kaffee"
+    "coffee": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaffee"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coffee"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coffee"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Café"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Café"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コーヒー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コーヒー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "커피"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "커피"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "咖啡"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "咖啡"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "咖啡"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "咖啡"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coffee"
+          }
         }
       }
     },
-    "cogwheel" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zahnrad"
+    "cogwheel": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zahnrad"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cogwheel"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cogwheel"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Engrenages"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Engrenages"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "歯車"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "歯車"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "톱니바퀴"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "톱니바퀴"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "齿轮"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "齿轮"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "齒輪"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "齒輪"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cogwheel"
+          }
         }
       }
     },
-    "corgi_welsh" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Welsh Corgi"
+    "corgi_welsh": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welsh Corgi"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welsh Corgi"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Welsh Corgi"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welsh Corgi"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Welsh Corgi"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウェルシュ・コーギー"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ウェルシュ・コーギー"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웰시코기"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웰시코기"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "柯基"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "柯基"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "柯基"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "柯基"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welsh Corgi"
           }
         }
       }
     },
-    "cradle" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kugelstoßpendel"
+    "cradle": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kugelstoßpendel"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Newton's Cradle"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Newton's Cradle"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pendule de Newton"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pendule de Newton"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ニュートンのゆりかご"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ニュートンのゆりかご"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "뉴턴의 요람"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "뉴턴의 요람"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "牛顿摆"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "牛顿摆"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "牛頓球"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "牛頓球"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Newton's Cradle"
           }
         }
       }
     },
-    "curve_sine" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sinuskurve"
+    "curve_sine": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sinuskurve"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sine Curve"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sine Curve"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Courbe sinusoïdale"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Courbe sinusoïdale"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイン波"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サイン波"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사인함수"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사인함수"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正弦曲线"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正弦曲线"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正弦曲線"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正弦曲線"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sine Curve"
           }
         }
       }
     },
-    "dinosaur" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dinosaurier"
+    "dinosaur": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dinosaurier"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dinosaur"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dinosaur"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dinosaure"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dinosaure"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "恐竜"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恐竜"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "공룡"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공룡"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "恐龙"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恐龙"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "恐龍"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恐龍"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dinosaur"
+          }
         }
       }
     },
-    "dog" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hund"
+    "dog": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hund"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dog"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dog"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chien"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chien"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "イヌ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イヌ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "狗"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "狗"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "狗"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "狗"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dog"
+          }
         }
       }
     },
-    "dogeza" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Japanische Entschuldigung"
+    "dogeza": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japanische Entschuldigung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japanese Apology"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Japanese Apology"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excuses Japonaise"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Excuses Japonaise"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "土下座"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "土下座"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도게자"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "도게자"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "土下座"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "土下座"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日式道歉"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日式道歉"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japanese Apology"
           }
         }
       }
     },
-    "dolphin" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delfin"
+    "dolphin": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delfin"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dolphin"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dolphin"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dauphin"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dauphin"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イルカ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "イルカ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "돌고래"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "돌고래"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "海豚"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "海豚"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "海豚"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "海豚"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dolphin"
           }
         }
       }
     },
-    "dots" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Punkte"
+    "dots": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punkte"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dots"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dots"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Points"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Points"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドット"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ドット"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "점"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "점"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点点"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "点点"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點點"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "點點"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dots"
           }
         }
       }
     },
-    "dragon" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Drache"
+    "dragon": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drache"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dragon"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dragon"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dragon"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dragon"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ドラゴン"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドラゴン"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "용"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "용"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "龙"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "龙"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "龍"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "龍"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dragon"
+          }
         }
       }
     },
-    "drink_tapioca" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tapioca-Getränk"
+    "drink_tapioca": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tapioca-Getränk"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tapioca Drink"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tapioca Drink"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verre de tapioca"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verre de tapioca"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "タピオカ ドリンク"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タピオカ ドリンク"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "버블티"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버블티"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "珍珠奶茶"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "珍珠奶茶"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "珍珠奶茶"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "珍珠奶茶"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tapioca Drink"
+          }
         }
       }
     },
-    "drop" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tropfen"
+    "drop": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tropfen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drop"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Drop"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Goutte"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Goutte"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水滴"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "水滴"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "물방울"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "물방울"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水滴"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "水滴"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水滴"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "水滴"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drop"
           }
         }
       }
     },
-    "duck_rubber" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quietscheente"
+    "duck_rubber": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quietscheente"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rubber Duck"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rubber Duck"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canard en plastique"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Canard en plastique"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お風呂のアヒル"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "お風呂のアヒル"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "러버덕"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "러버덕"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "橡皮鸭"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "橡皮鸭"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "橡皮鴨"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "橡皮鴨"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rubber Duck"
           }
         }
       }
     },
-    "earth" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erde"
+    "earth": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erde"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Earth"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Earth"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La Terre"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La Terre"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地球"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "地球"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지구"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "지구"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地球"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "地球"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地球"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "地球"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Earth"
           }
         }
       }
     },
-    "engine" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Motor"
+    "engine": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Motor"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Engine"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Engine"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Piston moteur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piston moteur"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エンジン"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エンジン"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "엔진"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "엔진"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "引擎"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "引擎"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "引擎"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "引擎"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Engine"
+          }
         }
       }
     },
-    "entaku" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entaku"
+    "entaku": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entaku"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entaku"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entaku"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entaku"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entaku"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "えんたく"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "えんたく"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entaku"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entaku"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entaku"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entaku"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entaku"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entaku"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entaku"
+          }
         }
       }
     },
-    "factory" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fabrik"
+    "factory": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fabrik"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Factory"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Factory"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usine"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usine"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工場"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "工場"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공장"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "공장"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工厂"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "工厂"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工廠"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "工廠"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Factory"
           }
         }
       }
     },
-    "fishman" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fischmann"
+    "fishman": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fischmann"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fish-Man"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fish-Man"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Homme-poisson"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Homme-poisson"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "魚男"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "魚男"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "생선남"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "생선남"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鱼人"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "鱼人"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "魚人"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "魚人"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fish-Man"
           }
         }
       }
     },
-    "fox" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fuchs"
+    "fox": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuchs"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fox"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fox"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renard"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renard"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キツネ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キツネ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "여우"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "여우"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "狐狸"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "狐狸"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "狐狸"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "狐狸"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fox"
           }
         }
       }
     },
-    "frog" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frosch"
+    "frog": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frosch"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frog"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frog"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grenouille"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grenouille"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "カエル"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カエル"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개구리"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개구리"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "青蛙"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "青蛙"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "青蛙"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "青蛙"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frog"
+          }
         }
       }
     },
-    "frypan" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bratpfanne"
+    "frypan": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bratpfanne"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frypan"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frypan"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poêle"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poêle"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フライパン"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フライパン"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "후라이팬"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후라이팬"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "平底锅"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "平底锅"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "平底鍋"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "平底鍋"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frypan"
+          }
         }
       }
     },
-    "ghost" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geist"
+    "ghost": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geist"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghost"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ghost"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fantôme"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fantôme"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "幽霊"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "幽霊"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "유령"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "유령"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "幽灵"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "幽灵"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "幽靈"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "幽靈"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghost"
           }
         }
       }
     },
-    "greyhound" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Windhund"
+    "greyhound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windhund"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Greyhound"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Greyhound"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lévrier"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lévrier"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グレイハウンド"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "グレイハウンド"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "그레이하운드"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "그레이하운드"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "灰狗"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "灰狗"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "灰狗"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "灰狗"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Greyhound"
           }
         }
       }
     },
-    "hedgehog" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Igel"
+    "hedgehog": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Igel"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hedgehog"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hedgehog"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hérisson"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hérisson"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ハリネズミ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ハリネズミ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고슴도치"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "고슴도치"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刺猬"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "刺猬"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刺蝟"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "刺蝟"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hedgehog"
           }
         }
       }
     },
-    "horse" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pferd"
+    "horse": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pferd"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Horse"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Horse"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cheval"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cheval"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "早馬"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "早馬"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "말"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "말"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "马"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "马"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "馬"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "馬"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Horse"
+          }
         }
       }
     },
-    "human" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mensch"
+    "human": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mensch"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Human"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Human"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Humain"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Humain"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヒト"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヒト"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "인간"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인간"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "人"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "人"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "人"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "人"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Human"
+          }
         }
       }
     },
-    "lantern_o_jack" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jack mit der Laterne"
+    "lantern_o_jack": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jack mit der Laterne"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jack O' Lantern"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jack O' Lantern"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Citrouille hantée"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Citrouille hantée"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ジャック・オー・ランタン"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ジャック・オー・ランタン"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "잭 오 랜턴"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "잭 오 랜턴"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "南瓜灯"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "南瓜灯"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "南瓜燈"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "南瓜燈"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jack O' Lantern"
           }
         }
       }
     },
-    "locomotive_steam" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dampflokomotive"
+    "locomotive_steam": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dampflokomotive"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Steam Locomotive"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Steam Locomotive"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Locomotive à vapeur"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Locomotive à vapeur"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "蒸気機関車"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "蒸気機関車"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "증기기관차"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "증기기관차"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "蒸汽机车"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "蒸汽机车"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "蒸汽火車"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "蒸汽火車"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Steam Locomotive"
           }
         }
       }
     },
-    "made_self" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selbsterstellter Läufer"
+    "made_self": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selbsterstellter Läufer"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Self-Made Runner"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Self-Made Runner"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coureur Personnalisé"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coureur Personnalisé"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自作ランナー"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自作ランナー"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "커스텀 러너"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "커스텀 러너"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自制跑者"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自制跑者"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自製跑者"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自製跑者"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Self-Made Corredor"
           }
         }
       }
     },
-    "mochi" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mochi"
+    "mochi": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mochi"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mochi"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mochi"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mochi"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mochi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "おもち"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "おもち"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "모찌"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모찌"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "年糕"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "年糕"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "麻糬"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麻糬"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mochi"
+          }
         }
       }
     },
-    "mouse" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maus"
+    "mouse": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mouse"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mouse"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Souris"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Souris"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ネズミ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネズミ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "쥐"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "쥐"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "老鼠"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "老鼠"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "老鼠"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "老鼠"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mouse"
+          }
         }
       }
     },
-    "neko_maneki" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Winkekatze"
+    "neko_maneki": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Winkekatze"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maneki Neko"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maneki Neko"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maneki Neko"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maneki Neko"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "招き猫"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "招き猫"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마네키네코"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "마네키네코"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "招财猫"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "招财猫"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "招財貓"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "招財貓"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maneki Neko"
           }
         }
       }
     },
-    "octopus" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oktopus"
+    "octopus": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oktopus"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Octopus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Octopus"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poulpe"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poulpe"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タコ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "タコ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문어"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "문어"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "章鱼"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "章鱼"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "章魚"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "章魚"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Octopus"
           }
         }
       }
     },
-    "otter" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otter"
+    "otter": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otter"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otter"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loutre"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loutre"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カワウソ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "カワウソ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수달"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "수달"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水獭"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "水獭"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水獺"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "水獺"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otter"
           }
         }
       }
     },
-    "owl" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eule"
+    "owl": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eule"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Owl"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Owl"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hibou"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hibou"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フクロウ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フクロウ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "부엉이"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "부엉이"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "猫头鹰"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "猫头鹰"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "貓頭鷹"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "貓頭鷹"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Owl"
+          }
         }
       }
     },
-    "parrot" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Papagei"
+    "parrot": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Papagei"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parrot"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parrot"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Perroquet"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perroquet"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "例のオウム"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例のオウム"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "앵무새"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앵무새"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "鹦鹉"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鹦鹉"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "鸚鵡"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鸚鵡"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parrot"
+          }
         }
       }
     },
-    "pendulum" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kuckucksuhr"
+    "pendulum": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kuckucksuhr"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pendulum"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pendulum"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pendule"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pendule"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "振り子"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "振り子"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "펜듈럼"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "펜듈럼"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "钟摆"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "钟摆"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鐘擺"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "鐘擺"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pendulum"
           }
         }
       }
     },
-    "penguin" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pinguin"
+    "penguin": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pinguin"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Penguin"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Penguin"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manchot"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Manchot"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペンギン"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ペンギン"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "펭귄"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "펭귄"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "企鹅"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "企鹅"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "企鵝"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "企鵝"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Penguin"
           }
         }
       }
     },
-    "penguin2" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pinguin 2"
+    "penguin2": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pinguin 2"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Penguin 2"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Penguin 2"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manchot 2"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Manchot 2"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペンギン２"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ペンギン２"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "펭귄 2"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "펭귄 2"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "企鹅 2"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "企鹅 2"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "企鵝 2"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "企鵝 2"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Penguin 2"
           }
         }
       }
     },
-    "people_party" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Party-Volk"
+    "people_party": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Party-Volk"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Party People"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Party People"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Foule en fête"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Foule en fête"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パリピ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パリピ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "인싸 파티"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인싸 파티"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "派对"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "派对"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "派對中的人們"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "派對中的人們"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Party People"
+          }
         }
       }
     },
-    "pig" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schwein"
+    "pig": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schwein"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pig"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pig"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cochon"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cochon"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ブタ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブタ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "돼지"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "돼지"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "小猪"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小猪"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "小豬"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小豬"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pig"
+          }
         }
       }
     },
-    "pulse" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Puls"
+    "pulse": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puls"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pulse"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pulse"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Battement"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Battement"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パルス"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パルス"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파동"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "파동"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "心跳"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "心跳"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "心跳"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "心跳"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pulse"
           }
         }
       }
     },
-    "puppy" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Welpe"
+    "puppy": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welpe"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puppy"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Puppy"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiot"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chiot"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "子犬"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "子犬"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "강아지"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "강아지"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小狗"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "小狗"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小狗"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "小狗"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puppy"
           }
         }
       }
     },
-    "rabbit" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hase"
+    "rabbit": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hase"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rabbit"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rabbit"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lapin"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lapin"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウサギ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ウサギ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "토끼"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "토끼"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小兔子"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "小兔子"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小兔子"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "小兔子"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rabbit"
           }
         }
       }
     },
-    "reactor" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reaktor"
+    "reactor": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reaktor"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reactor"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reactor"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réacteur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réacteur"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "彼のリアクター"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "彼のリアクター"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "원자로"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "원자로"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "反应堆"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "反应堆"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "反應爐"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "反應爐"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reactor"
+          }
         }
       }
     },
-    "rocket" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rakete"
+    "rocket": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rakete"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rocket"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rocket"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fusée"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fusée"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ロケット"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ロケット"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "로켓"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로켓"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "火箭"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "火箭"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "火箭"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "火箭"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rocket"
+          }
         }
       }
     },
-    "runners_all" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Läufer freischalten"
+    "runners_all": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Läufer freischalten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock All Runners"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unlock All Runners"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Débloquer tous les Coureurs"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Débloquer tous les Coureurs"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全ランナー開放"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "全ランナー開放"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 러너 해제"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "모든 러너 해제"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解锁所有跑者"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "解锁所有跑者"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解鎖所有跑者"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "解鎖所有跑者"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock All Corredors"
           }
         }
       }
     },
-    "sausage" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wurst"
+    "sausage": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurst"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sausage"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sausage"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saucisse"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saucisse"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "踊るソーセージ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "踊るソーセージ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소세지"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "소세지"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "香肠"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "香肠"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "香腸"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "香腸"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sausage"
           }
         }
       }
     },
-    "sheep" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schaf"
+    "sheep": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schaf"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sheep"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sheep"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mouton"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mouton"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヒツジ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヒツジ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "양"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "양"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "绵羊"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "绵羊"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "綿羊"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "綿羊"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sheep"
           }
         }
       }
     },
-    "sleigh_reindeer" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rentier & Schlitten"
+    "sleigh_reindeer": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rentier & Schlitten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reindeer & Sleigh"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reindeer & Sleigh"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Traineau de Rennes"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traineau de Rennes"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "トナカイとソリ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トナカイとソリ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "루돌프와 썰매"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "루돌프와 썰매"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "驯鹿与雪橇"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "驯鹿与雪橇"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "馴鹿與雪橇"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "馴鹿與雪橇"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reindeer & Sleigh"
+          }
         }
       }
     },
-    "slime" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schleim"
+    "slime": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schleim"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slime"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slime"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slime"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slime"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スライム"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スライム"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "슬라임"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "슬라임"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "史莱姆"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "史莱姆"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "史萊姆"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "史萊姆"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slime"
+          }
         }
       }
     },
-    "snowman" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schneemann"
+    "snowman": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schneemann"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snowman"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snowman"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bonhomme de neige"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bonhomme de neige"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "雪だるま"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "雪だるま"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "눈사람"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "눈사람"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "雪人"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "雪人"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "雪人"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "雪人"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snowman"
           }
         }
       }
     },
-    "sparkler" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wunderkerze"
+    "sparkler": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wunderkerze"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkler"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sparkler"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feux d'artifice"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feux d'artifice"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "線香花火"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "線香花火"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "불꽃놀이"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "불꽃놀이"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "烟花棒"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "烟花棒"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仙女棒"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "仙女棒"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sparkler"
           }
         }
       }
     },
-    "squirrel" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eichhörnchen"
+    "squirrel": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eichhörnchen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Squirrel"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Squirrel"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Écureuil"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Écureuil"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リス"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リス"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다람쥐"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "다람쥐"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "松鼠"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "松鼠"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "松鼠"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "松鼠"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Squirrel"
           }
         }
       }
     },
-    "sushi" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sushi"
+    "sushi": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sushi"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sushi"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sushi"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sushi"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sushi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "お寿司"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お寿司"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "초밥"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "초밥"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "寿司"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寿司"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "壽司"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "壽司"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sushi"
+          }
         }
       }
     },
-    "sushi_rotating" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Drehendes Sushi"
+    "sushi_rotating": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drehendes Sushi"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rotating Sushi"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rotating Sushi"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sushi en rotation"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sushi en rotation"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "回転寿司"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回転寿司"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "회전초밥"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "회전초밥"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "回转寿司"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回转寿司"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "迴轉壽司"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "迴轉壽司"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rotating Sushi"
+          }
         }
       }
     },
-    "tail_cat" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Katzenschwanz"
+    "tail_cat": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Katzenschwanz"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cat Tail"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cat Tail"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Queue de chat"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Queue de chat"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "猫のしっぽ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "猫のしっぽ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "누웠냥"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "누웠냥"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "猫尾"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "猫尾"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "貓尾巴"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "貓尾巴"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cat Tail"
           }
         }
       }
     },
-    "terrier" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terrier"
+    "terrier": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terrier"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terrier"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terrier"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terrier"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terrier"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テリア犬"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "テリア犬"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테리어"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "테리어"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "梗犬"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "梗犬"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "梗犬"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "梗犬"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terrier"
           }
         }
       }
     },
-    "triforce" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kraft, Weisheit, Mut"
+    "triforce": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kraft, Weisheit, Mut"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Power, Wisdom, Courage"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Power, Wisdom, Courage"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Force, Sagesse, Courage"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Force, Sagesse, Courage"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "力、知恵、勇気"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "力、知恵、勇気"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "힘, 지혜, 용기"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "힘, 지혜, 용기"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "力量，智慧，勇气"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "力量，智慧，勇气"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "力量，智慧，勇氣"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "力量，智慧，勇氣"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Power, Wisdom, Courage"
           }
         }
       }
     },
-    "uhooi" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uhooi"
+    "uhooi": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uhooi"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uhooi"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uhooi"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uhooi"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uhooi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ウホーイ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウホーイ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uhooi"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uhooi"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uhooi"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uhooi"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uhooi"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uhooi"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uhooi"
+          }
         }
       }
     },
-    "up_push" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Liegestütz"
+    "up_push": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liegestütz"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Push-Up"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Push-Up"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pompe"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pompe"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "腕立て伏せ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "腕立て伏せ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "푸쉬업"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "푸쉬업"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "俯卧撑"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "俯卧撑"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "伏地挺身"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "伏地挺身"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Push-Up"
+          }
         }
       }
     },
-    "up_sit" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sit-Up"
+    "up_sit": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sit-Up"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sit-Up"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sit-Up"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abdominaux"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abdominaux"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "腹筋"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "腹筋"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "싯업"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "싯업"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仰卧起坐"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "仰卧起坐"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仰臥起坐"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "仰臥起坐"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sit-Up"
           }
         }
       }
     },
-    "whale" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wal"
+    "whale": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wal"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whale"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Whale"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baleine"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baleine"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クジラ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "クジラ"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고래"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "고래"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鲸鱼"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "鲸鱼"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鯨魚"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "鯨魚"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Whale"
           }
         }
       }
     },
-    "wheel_hamster" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hamsterrad"
+    "wheel_hamster": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hamsterrad"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hamster Wheel"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hamster Wheel"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Roue de Hamster"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Roue de Hamster"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ハムスターと回し車"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ハムスターと回し車"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "쳇바퀴"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "쳇바퀴"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仓鼠跑轮"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "仓鼠跑轮"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "倉鼠跑輪子"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "倉鼠跑輪子"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hamster Wheel"
           }
         }
       }
     }
   },
-  "version" : "1_0"
+  "version": "1_0"
 }

--- a/Sources/RunCatLocalization/Resources/RunnerName.xcstrings
+++ b/Sources/RunCatLocalization/Resources/RunnerName.xcstrings
@@ -516,7 +516,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nyan Cat"
+            "value" : "Imitación de Nyan Cat."
           }
         }
       }

--- a/Sources/RunCatLocalization/Resources/RunnerName.xcstrings
+++ b/Sources/RunCatLocalization/Resources/RunnerName.xcstrings
@@ -1,4166 +1,3686 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "b_cat": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Katze β"
+  "sourceLanguage" : "en",
+  "strings" : {
+    "b_cat" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Katze β"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cat β"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cat β"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chat β"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chat β"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネコ β"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネコ β"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "베타냥"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "베타냥"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "β 猫"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "β 猫"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "β 貓"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "β 貓"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cat β"
-          }
         }
       }
     },
-    "bird": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vogel"
+    "bird" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vogel"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bird"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bird"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oiseau"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oiseau"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "トリ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トリ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "새"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "새"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "小鸟"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小鸟"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "小鳥"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小鳥"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bird"
-          }
         }
       }
     },
-    "bonfire": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lagerfeuer"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bonfire"
+    "bonfire" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lagerfeuer"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feu de camp"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bonfire"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "焚き火"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feu de camp"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모닥불"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "焚き火"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "篝火"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모닥불"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "營火"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "篝火"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bonfire"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "營火"
           }
         }
       }
     },
-    "butterfly": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schmetterling"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Butterfly"
+    "butterfly" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schmetterling"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Papillon"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Butterfly"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "蝶々"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Papillon"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "나비"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蝶々"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "蝴蝶"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "나비"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "蝴蝶"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蝴蝶"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Butterfly"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蝴蝶"
           }
         }
       }
     },
-    "c_cat": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Katze γ"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cat γ"
+    "c_cat" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Katze γ"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chat γ"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cat γ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネコ γ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chat γ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "감마냥"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネコ γ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "γ 猫"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "감마냥"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "γ 貓"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "γ 猫"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cat γ"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "γ 貓"
           }
         }
       }
     },
-    "cat": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Katze α"
+    "cat" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Katze α"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cat α"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cat α"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chat α"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chat α"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネコ α"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネコ α"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "알파냥"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알파냥"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "α 猫"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "α 猫"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "α 貓"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "α 貓"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cat α"
-          }
         }
       }
     },
-    "cat_cluster_metal": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Metallcluster-Katze"
+    "cat_cluster_metal" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metallcluster-Katze"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Metal Cluster Cat"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metal Cluster Cat"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chat Métal Cluster"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chat Métal Cluster"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "メタルクラスタキャット"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メタルクラスタキャット"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "메탈냥"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메탈냥"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "金属团猫"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "金属团猫"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "金屬簇貓"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "金屬簇貓"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Metal Cluster Cat"
-          }
         }
       }
     },
-    "cat_flash": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Flash-Katze"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Flash Cat"
+    "cat_flash" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flash-Katze"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chat Flash"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flash Cat"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "赤い閃光猫"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chat Flash"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "플래시냥"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "赤い閃光猫"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "闪电猫"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "플래시냥"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "閃電貓"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "闪电猫"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Flash Cat"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閃電貓"
           }
         }
       }
     },
-    "cat_golden": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Goldene Katze"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Golden Cat"
+    "cat_golden" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Goldene Katze"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chat doré"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Golden Cat"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "黄金のネコ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chat doré"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "골든냥"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "黄金のネコ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "金猫"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "골든냥"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "黃金貓"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "金猫"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Golden Cat"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "黃金貓"
           }
         }
       }
     },
-    "cat_nyan_mock": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mock Nyan Cat"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mock Nyan Cat"
+    "cat_nyan_mock" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mock Nyan Cat"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réplique Nyan Cat"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mock Nyan Cat"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nyan Catもどき"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réplique Nyan Cat"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "디스크 냥캣"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nyan Catもどき"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "模仿彩虹猫"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "디스크 냥캣"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仿彩虹貓"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模仿彩虹猫"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mock Nyan Cat"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仿彩虹貓"
           }
         }
       }
     },
-    "chameleon": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chamäleon"
+    "chameleon" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chamäleon"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chameleon"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chameleon"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Caméléon"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caméléon"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カメレオン"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カメレオン"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "카멜레온"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카멜레온"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "变色龙"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "变色龙"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "變色龍"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "變色龍"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chameleon"
-          }
         }
       }
     },
-    "cheetah": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gepard"
+    "cheetah" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gepard"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cheetah"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cheetah"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Guépard"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guépard"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "チーター"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チーター"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "치타"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "치타"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "猎豹"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "猎豹"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "獵豹"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "獵豹"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cheetah"
-          }
         }
       }
     },
-    "chicken": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Huhn"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chicken"
+    "chicken" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Huhn"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poule"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chicken"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ニワトリ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poule"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "닭"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ニワトリ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "小鸡"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "닭"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "小雞"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小鸡"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chicken"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小雞"
           }
         }
       }
     },
-    "chime_wind": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Windspiel"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wind Chime"
+    "chime_wind" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Windspiel"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Carillon à vent"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wind Chime"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "風鈴"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carillon à vent"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "풍경"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "風鈴"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "风铃"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "풍경"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "風鈴"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "风铃"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wind Chime"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "風鈴"
           }
         }
       }
     },
-    "city": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stadt"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "City"
+    "city" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stadt"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ville"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "City"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "都会"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ville"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "도시"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "都会"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "城市"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도시"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "城市"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "城市"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "City"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "城市"
           }
         }
       }
     },
-    "coffee": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kaffee"
+    "coffee" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaffee"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coffee"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coffee"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Café"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Café"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コーヒー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コーヒー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "커피"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커피"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "咖啡"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "咖啡"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "咖啡"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "咖啡"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coffee"
-          }
         }
       }
     },
-    "cogwheel": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zahnrad"
+    "cogwheel" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zahnrad"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cogwheel"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cogwheel"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Engrenages"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Engrenages"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "歯車"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歯車"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "톱니바퀴"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "톱니바퀴"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "齿轮"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "齿轮"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "齒輪"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "齒輪"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cogwheel"
-          }
         }
       }
     },
-    "corgi_welsh": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Welsh Corgi"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Welsh Corgi"
+    "corgi_welsh" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Welsh Corgi"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Welsh Corgi"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Welsh Corgi"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ウェルシュ・コーギー"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Welsh Corgi"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "웰시코기"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウェルシュ・コーギー"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "柯基"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웰시코기"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "柯基"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "柯基"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Welsh Corgi"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "柯基"
           }
         }
       }
     },
-    "cradle": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kugelstoßpendel"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Newton's Cradle"
+    "cradle" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kugelstoßpendel"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pendule de Newton"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Newton's Cradle"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ニュートンのゆりかご"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendule de Newton"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "뉴턴의 요람"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ニュートンのゆりかご"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "牛顿摆"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "뉴턴의 요람"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "牛頓球"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "牛顿摆"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Newton's Cradle"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "牛頓球"
           }
         }
       }
     },
-    "curve_sine": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sinuskurve"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sine Curve"
+    "curve_sine" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sinuskurve"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Courbe sinusoïdale"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sine Curve"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サイン波"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Courbe sinusoïdale"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사인함수"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サイン波"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正弦曲线"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사인함수"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正弦曲線"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正弦曲线"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sine Curve"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正弦曲線"
           }
         }
       }
     },
-    "dinosaur": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dinosaurier"
+    "dinosaur" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinosaurier"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dinosaur"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinosaur"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dinosaure"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinosaure"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "恐竜"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恐竜"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "공룡"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "공룡"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "恐龙"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恐龙"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "恐龍"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恐龍"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dinosaur"
-          }
         }
       }
     },
-    "dog": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hund"
+    "dog" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hund"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dog"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dog"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chien"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chien"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "イヌ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イヌ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "개"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "狗"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狗"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "狗"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狗"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dog"
-          }
         }
       }
     },
-    "dogeza": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Japanische Entschuldigung"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Japanese Apology"
+    "dogeza" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Japanische Entschuldigung"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Excuses Japonaise"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Japanese Apology"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "土下座"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Excuses Japonaise"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "도게자"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "土下座"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "土下座"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도게자"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日式道歉"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "土下座"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Japanese Apology"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日式道歉"
           }
         }
       }
     },
-    "dolphin": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delfin"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dolphin"
+    "dolphin" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delfin"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dauphin"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dolphin"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "イルカ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dauphin"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "돌고래"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イルカ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "海豚"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "돌고래"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "海豚"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "海豚"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dolphin"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "海豚"
           }
         }
       }
     },
-    "dots": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Punkte"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dots"
+    "dots" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Punkte"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Points"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dots"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ドット"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Points"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "점"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドット"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点点"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "점"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "點點"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点点"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dots"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點點"
           }
         }
       }
     },
-    "dragon": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Drache"
+    "dragon" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drache"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dragon"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dragon"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dragon"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dragon"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ドラゴン"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドラゴン"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "용"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "용"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "龙"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "龙"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "龍"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "龍"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dragon"
-          }
         }
       }
     },
-    "drink_tapioca": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tapioca-Getränk"
+    "drink_tapioca" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tapioca-Getränk"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tapioca Drink"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tapioca Drink"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verre de tapioca"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verre de tapioca"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タピオカ ドリンク"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タピオカ ドリンク"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "버블티"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버블티"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "珍珠奶茶"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "珍珠奶茶"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "珍珠奶茶"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "珍珠奶茶"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tapioca Drink"
-          }
         }
       }
     },
-    "drop": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tropfen"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Drop"
+    "drop" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tropfen"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Goutte"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drop"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水滴"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Goutte"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "물방울"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水滴"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水滴"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "물방울"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水滴"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水滴"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Drop"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水滴"
           }
         }
       }
     },
-    "duck_rubber": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quietscheente"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rubber Duck"
+    "duck_rubber" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quietscheente"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Canard en plastique"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rubber Duck"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "お風呂のアヒル"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Canard en plastique"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "러버덕"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お風呂のアヒル"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "橡皮鸭"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "러버덕"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "橡皮鴨"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "橡皮鸭"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rubber Duck"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "橡皮鴨"
           }
         }
       }
     },
-    "earth": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erde"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Earth"
+    "earth" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erde"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La Terre"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Earth"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "地球"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La Terre"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "지구"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地球"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "地球"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지구"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "地球"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地球"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Earth"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地球"
           }
         }
       }
     },
-    "engine": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Motor"
+    "engine" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Motor"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Engine"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Engine"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piston moteur"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piston moteur"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エンジン"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エンジン"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "엔진"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "엔진"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "引擎"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "引擎"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "引擎"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "引擎"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Engine"
-          }
         }
       }
     },
-    "entaku": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entaku"
+    "entaku" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entaku"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entaku"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entaku"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entaku"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entaku"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "えんたく"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "えんたく"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entaku"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entaku"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entaku"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entaku"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entaku"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entaku"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entaku"
-          }
         }
       }
     },
-    "factory": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fabrik"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Factory"
+    "factory" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fabrik"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usine"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Factory"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "工場"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usine"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "공장"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工場"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "工厂"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "공장"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "工廠"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工厂"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Factory"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工廠"
           }
         }
       }
     },
-    "fishman": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fischmann"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fish-Man"
+    "fishman" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fischmann"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Homme-poisson"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fish-Man"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "魚男"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Homme-poisson"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "생선남"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "魚男"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "鱼人"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "생선남"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "魚人"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鱼人"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fish-Man"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "魚人"
           }
         }
       }
     },
-    "fox": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fuchs"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fox"
+    "fox" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuchs"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Renard"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fox"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キツネ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renard"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "여우"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キツネ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "狐狸"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여우"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "狐狸"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狐狸"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fox"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狐狸"
           }
         }
       }
     },
-    "frog": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frosch"
+    "frog" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frosch"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frog"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frog"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Grenouille"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grenouille"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カエル"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カエル"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "개구리"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개구리"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "青蛙"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "青蛙"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "青蛙"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "青蛙"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frog"
-          }
         }
       }
     },
-    "frypan": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bratpfanne"
+    "frypan" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bratpfanne"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frypan"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frypan"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poêle"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poêle"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フライパン"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フライパン"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "후라이팬"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "후라이팬"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "平底锅"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平底锅"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "平底鍋"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平底鍋"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frypan"
-          }
         }
       }
     },
-    "ghost": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geist"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ghost"
+    "ghost" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geist"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fantôme"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ghost"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "幽霊"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fantôme"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "유령"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "幽霊"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "幽灵"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "유령"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "幽靈"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "幽灵"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ghost"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "幽靈"
           }
         }
       }
     },
-    "greyhound": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Windhund"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Greyhound"
+    "greyhound" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Windhund"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lévrier"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Greyhound"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "グレイハウンド"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lévrier"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "그레이하운드"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "グレイハウンド"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "灰狗"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "그레이하운드"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "灰狗"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "灰狗"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Greyhound"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "灰狗"
           }
         }
       }
     },
-    "hedgehog": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Igel"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hedgehog"
+    "hedgehog" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Igel"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hérisson"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedgehog"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ハリネズミ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hérisson"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "고슴도치"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ハリネズミ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "刺猬"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "고슴도치"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "刺蝟"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刺猬"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hedgehog"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刺蝟"
           }
         }
       }
     },
-    "horse": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pferd"
+    "horse" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pferd"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Horse"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Horse"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cheval"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cheval"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "早馬"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "早馬"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "말"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "말"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "马"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "马"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "馬"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "馬"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Horse"
-          }
         }
       }
     },
-    "human": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mensch"
+    "human" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensch"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Human"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Human"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Humain"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Humain"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ヒト"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヒト"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "인간"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인간"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "人"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "人"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "人"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Human"
-          }
         }
       }
     },
-    "lantern_o_jack": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jack mit der Laterne"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jack O' Lantern"
+    "lantern_o_jack" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jack mit der Laterne"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Citrouille hantée"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jack O' Lantern"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ジャック・オー・ランタン"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Citrouille hantée"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "잭 오 랜턴"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ジャック・オー・ランタン"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "南瓜灯"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잭 오 랜턴"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "南瓜燈"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "南瓜灯"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jack O' Lantern"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "南瓜燈"
           }
         }
       }
     },
-    "locomotive_steam": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dampflokomotive"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Steam Locomotive"
+    "locomotive_steam" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dampflokomotive"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Locomotive à vapeur"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steam Locomotive"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "蒸気機関車"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Locomotive à vapeur"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "증기기관차"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蒸気機関車"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "蒸汽机车"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "증기기관차"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "蒸汽火車"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蒸汽机车"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Steam Locomotive"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "蒸汽火車"
           }
         }
       }
     },
-    "made_self": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selbsterstellter Läufer"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Self-Made Runner"
+    "made_self" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selbsterstellter Läufer"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coureur Personnalisé"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Self-Made Runner"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自作ランナー"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coureur Personnalisé"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "커스텀 러너"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自作ランナー"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自制跑者"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커스텀 러너"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自製跑者"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自制跑者"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Self-Made Corredor"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自製跑者"
           }
         }
       }
     },
-    "mochi": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mochi"
+    "mochi" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mochi"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mochi"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mochi"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mochi"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mochi"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "おもち"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "おもち"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모찌"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모찌"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "年糕"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年糕"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "麻糬"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "麻糬"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mochi"
-          }
         }
       }
     },
-    "mouse": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maus"
+    "mouse" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maus"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mouse"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mouse"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Souris"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Souris"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネズミ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネズミ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "쥐"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "쥐"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "老鼠"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "老鼠"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "老鼠"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "老鼠"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mouse"
-          }
         }
       }
     },
-    "neko_maneki": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Winkekatze"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maneki Neko"
+    "neko_maneki" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Winkekatze"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maneki Neko"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maneki Neko"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "招き猫"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maneki Neko"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "마네키네코"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "招き猫"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "招财猫"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마네키네코"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "招財貓"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "招财猫"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maneki Neko"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "招財貓"
           }
         }
       }
     },
-    "octopus": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oktopus"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Octopus"
+    "octopus" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oktopus"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poulpe"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Octopus"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タコ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poulpe"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "문어"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タコ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "章鱼"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "문어"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "章魚"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章鱼"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Octopus"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章魚"
           }
         }
       }
     },
-    "otter": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otter"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otter"
+    "otter" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otter"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loutre"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otter"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カワウソ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loutre"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "수달"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カワウソ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水獭"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수달"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水獺"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水獭"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otter"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水獺"
           }
         }
       }
     },
-    "owl": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eule"
+    "owl" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eule"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Owl"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Owl"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hibou"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hibou"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フクロウ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フクロウ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "부엉이"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "부엉이"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "猫头鹰"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "猫头鹰"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "貓頭鷹"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貓頭鷹"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Owl"
-          }
         }
       }
     },
-    "parrot": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Papagei"
+    "parrot" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Papagei"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parrot"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parrot"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Perroquet"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Perroquet"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "例のオウム"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例のオウム"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "앵무새"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앵무새"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "鹦鹉"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鹦鹉"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "鸚鵡"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鸚鵡"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parrot"
-          }
         }
       }
     },
-    "pendulum": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kuckucksuhr"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pendulum"
+    "pendulum" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kuckucksuhr"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pendule"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendulum"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "振り子"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendule"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "펜듈럼"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "振り子"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "钟摆"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "펜듈럼"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "鐘擺"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "钟摆"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pendulum"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鐘擺"
           }
         }
       }
     },
-    "penguin": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pinguin"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Penguin"
+    "penguin" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pinguin"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manchot"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penguin"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ペンギン"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manchot"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "펭귄"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ペンギン"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "企鹅"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "펭귄"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "企鵝"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "企鹅"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Penguin"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "企鵝"
           }
         }
       }
     },
-    "penguin2": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pinguin 2"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Penguin 2"
+    "penguin2" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pinguin 2"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manchot 2"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Penguin 2"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ペンギン２"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manchot 2"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "펭귄 2"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ペンギン２"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "企鹅 2"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "펭귄 2"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "企鵝 2"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "企鹅 2"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Penguin 2"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "企鵝 2"
           }
         }
       }
     },
-    "people_party": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Party-Volk"
+    "people_party" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Party-Volk"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Party People"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Party People"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Foule en fête"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Foule en fête"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パリピ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パリピ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "인싸 파티"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인싸 파티"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "派对"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "派对"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "派對中的人們"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "派對中的人們"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Party People"
-          }
         }
       }
     },
-    "pig": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schwein"
+    "pig" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schwein"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pig"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pig"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cochon"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cochon"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブタ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ブタ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "돼지"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "돼지"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "小猪"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小猪"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "小豬"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小豬"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pig"
-          }
         }
       }
     },
-    "pulse": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Puls"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pulse"
+    "pulse" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puls"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Battement"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulse"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パルス"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Battement"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "파동"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パルス"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "心跳"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "파동"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "心跳"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "心跳"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pulse"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "心跳"
           }
         }
       }
     },
-    "puppy": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Welpe"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Puppy"
+    "puppy" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Welpe"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chiot"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puppy"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "子犬"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiot"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "강아지"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "子犬"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "小狗"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "강아지"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "小狗"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小狗"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Puppy"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小狗"
           }
         }
       }
     },
-    "rabbit": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hase"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rabbit"
+    "rabbit" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hase"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lapin"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rabbit"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ウサギ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lapin"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "토끼"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウサギ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "小兔子"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "토끼"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "小兔子"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小兔子"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rabbit"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小兔子"
           }
         }
       }
     },
-    "reactor": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reaktor"
+    "reactor" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reaktor"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reactor"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reactor"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réacteur"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réacteur"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "彼のリアクター"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彼のリアクター"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "원자로"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "원자로"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "反应堆"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "反应堆"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "反應爐"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "反應爐"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reactor"
-          }
         }
       }
     },
-    "rocket": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rakete"
+    "rocket" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rakete"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rocket"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rocket"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fusée"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fusée"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ロケット"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ロケット"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "로켓"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로켓"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "火箭"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "火箭"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "火箭"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "火箭"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rocket"
-          }
         }
       }
     },
-    "runners_all": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alle Läufer freischalten"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unlock All Runners"
+    "runners_all" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Läufer freischalten"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Débloquer tous les Coureurs"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unlock All Runners"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全ランナー開放"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Débloquer tous les Coureurs"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모든 러너 해제"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全ランナー開放"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "解锁所有跑者"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 러너 해제"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "解鎖所有跑者"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解锁所有跑者"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unlock All Corredors"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解鎖所有跑者"
           }
         }
       }
     },
-    "sausage": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wurst"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sausage"
+    "sausage" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wurst"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Saucisse"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sausage"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "踊るソーセージ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saucisse"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "소세지"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "踊るソーセージ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "香肠"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "소세지"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "香腸"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "香肠"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sausage"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "香腸"
           }
         }
       }
     },
-    "sheep": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schaf"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sheep"
+    "sheep" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schaf"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mouton"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sheep"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ヒツジ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mouton"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "양"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヒツジ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "绵羊"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "양"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "綿羊"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "绵羊"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sheep"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綿羊"
           }
         }
       }
     },
-    "sleigh_reindeer": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rentier & Schlitten"
+    "sleigh_reindeer" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rentier & Schlitten"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reindeer & Sleigh"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reindeer & Sleigh"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Traineau de Rennes"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traineau de Rennes"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "トナカイとソリ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トナカイとソリ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "루돌프와 썰매"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "루돌프와 썰매"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "驯鹿与雪橇"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驯鹿与雪橇"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "馴鹿與雪橇"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "馴鹿與雪橇"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reindeer & Sleigh"
-          }
         }
       }
     },
-    "slime": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schleim"
+    "slime" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schleim"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Slime"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slime"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Slime"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slime"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "スライム"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スライム"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "슬라임"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "슬라임"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "史莱姆"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "史莱姆"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "史萊姆"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "史萊姆"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Slime"
-          }
         }
       }
     },
-    "snowman": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schneemann"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Snowman"
+    "snowman" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schneemann"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bonhomme de neige"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Snowman"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "雪だるま"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bonhomme de neige"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "눈사람"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "雪だるま"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "雪人"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "눈사람"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "雪人"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "雪人"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Snowman"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "雪人"
           }
         }
       }
     },
-    "sparkler": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wunderkerze"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sparkler"
+    "sparkler" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wunderkerze"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feux d'artifice"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sparkler"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "線香花火"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feux d'artifice"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "불꽃놀이"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "線香花火"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "烟花棒"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "불꽃놀이"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仙女棒"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "烟花棒"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sparkler"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仙女棒"
           }
         }
       }
     },
-    "squirrel": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eichhörnchen"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Squirrel"
+    "squirrel" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eichhörnchen"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Écureuil"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Squirrel"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リス"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écureuil"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "다람쥐"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リス"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "松鼠"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다람쥐"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "松鼠"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "松鼠"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Squirrel"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "松鼠"
           }
         }
       }
     },
-    "sushi": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sushi"
+    "sushi" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sushi"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sushi"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sushi"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sushi"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sushi"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "お寿司"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お寿司"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "초밥"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "초밥"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "寿司"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寿司"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "壽司"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "壽司"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sushi"
-          }
         }
       }
     },
-    "sushi_rotating": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Drehendes Sushi"
+    "sushi_rotating" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drehendes Sushi"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rotating Sushi"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotating Sushi"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sushi en rotation"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sushi en rotation"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "回転寿司"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回転寿司"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "회전초밥"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "회전초밥"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "回转寿司"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回转寿司"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "迴轉壽司"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "迴轉壽司"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rotating Sushi"
-          }
         }
       }
     },
-    "tail_cat": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Katzenschwanz"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cat Tail"
+    "tail_cat" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Katzenschwanz"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Queue de chat"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cat Tail"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "猫のしっぽ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Queue de chat"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "누웠냥"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "猫のしっぽ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "猫尾"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "누웠냥"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "貓尾巴"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "猫尾"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cat Tail"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "貓尾巴"
           }
         }
       }
     },
-    "terrier": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terrier"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terrier"
+    "terrier" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terrier"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terrier"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terrier"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "テリア犬"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terrier"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "테리어"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テリア犬"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "梗犬"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "테리어"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "梗犬"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "梗犬"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terrier"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "梗犬"
           }
         }
       }
     },
-    "triforce": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kraft, Weisheit, Mut"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Power, Wisdom, Courage"
+    "triforce" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kraft, Weisheit, Mut"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Force, Sagesse, Courage"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Power, Wisdom, Courage"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "力、知恵、勇気"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Force, Sagesse, Courage"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "힘, 지혜, 용기"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "力、知恵、勇気"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "力量，智慧，勇气"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "힘, 지혜, 용기"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "力量，智慧，勇氣"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "力量，智慧，勇气"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Power, Wisdom, Courage"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "力量，智慧，勇氣"
           }
         }
       }
     },
-    "uhooi": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uhooi"
+    "uhooi" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uhooi"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uhooi"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uhooi"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uhooi"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uhooi"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ウホーイ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウホーイ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uhooi"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uhooi"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uhooi"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uhooi"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uhooi"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uhooi"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uhooi"
-          }
         }
       }
     },
-    "up_push": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liegestütz"
+    "up_push" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liegestütz"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Push-Up"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Push-Up"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pompe"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pompe"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "腕立て伏せ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "腕立て伏せ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "푸쉬업"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "푸쉬업"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "俯卧撑"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "俯卧撑"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "伏地挺身"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "伏地挺身"
           }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Push-Up"
-          }
         }
       }
     },
-    "up_sit": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sit-Up"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sit-Up"
+    "up_sit" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sit-Up"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abdominaux"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sit-Up"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "腹筋"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abdominaux"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "싯업"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "腹筋"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仰卧起坐"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "싯업"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仰臥起坐"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仰卧起坐"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sit-Up"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仰臥起坐"
           }
         }
       }
     },
-    "whale": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wal"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Whale"
+    "whale" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wal"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Baleine"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Whale"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クジラ"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baleine"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "고래"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クジラ"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "鲸鱼"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "고래"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "鯨魚"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鲸鱼"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Whale"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鯨魚"
           }
         }
       }
     },
-    "wheel_hamster": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hamsterrad"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hamster Wheel"
+    "wheel_hamster" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hamsterrad"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Roue de Hamster"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hamster Wheel"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ハムスターと回し車"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roue de Hamster"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "쳇바퀴"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ハムスターと回し車"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仓鼠跑轮"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "쳇바퀴"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "倉鼠跑輪子"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仓鼠跑轮"
           }
         },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hamster Wheel"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "倉鼠跑輪子"
           }
         }
       }
     }
   },
-  "version": "1_0"
+  "version" : "1_0"
 }

--- a/Sources/RunCatLocalization/Resources/RunnerName.xcstrings
+++ b/Sources/RunCatLocalization/Resources/RunnerName.xcstrings
@@ -1651,6 +1651,12 @@
             "value" : "Entaku"
           }
         },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entaku"
+          }
+        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3933,6 +3939,13 @@
             "value" : "Uhooi"
           }
         },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uhooi"
+          }
+        }
+      },
         "es" : {
           "stringUnit" : {
             "state" : "translated",

--- a/Sources/RunCatLocalization/Resources/RunnerName.xcstrings
+++ b/Sources/RunCatLocalization/Resources/RunnerName.xcstrings
@@ -44,6 +44,12 @@
             "state" : "translated",
             "value" : "β 貓"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gato β"
+          }
         }
       }
     },
@@ -89,6 +95,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "小鳥"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pájaro"
           }
         }
       }
@@ -136,6 +148,12 @@
             "state" : "translated",
             "value" : "營火"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoguera"
+          }
         }
       }
     },
@@ -181,6 +199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "蝴蝶"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mariposa"
           }
         }
       }
@@ -228,6 +252,12 @@
             "state" : "translated",
             "value" : "γ 貓"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gato γ"
+          }
         }
       }
     },
@@ -273,6 +303,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "α 貓"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gato α"
           }
         }
       }
@@ -320,6 +356,12 @@
             "state" : "translated",
             "value" : "金屬簇貓"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gato Metal Cluster"
+          }
         }
       }
     },
@@ -365,6 +407,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閃電貓"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gato Flash"
           }
         }
       }
@@ -412,6 +460,12 @@
             "state" : "translated",
             "value" : "黃金貓"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gato Dorado"
+          }
         }
       }
     },
@@ -457,6 +511,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "仿彩虹貓"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nyan Cat"
           }
         }
       }
@@ -504,6 +564,12 @@
             "state" : "translated",
             "value" : "變色龍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Camaleón"
+          }
         }
       }
     },
@@ -549,6 +615,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "獵豹"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guepardo"
           }
         }
       }
@@ -596,6 +668,12 @@
             "state" : "translated",
             "value" : "小雞"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pollo"
+          }
         }
       }
     },
@@ -641,6 +719,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "風鈴"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carillón de viento"
           }
         }
       }
@@ -688,6 +772,12 @@
             "state" : "translated",
             "value" : "城市"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ciudad"
+          }
         }
       }
     },
@@ -733,6 +823,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "咖啡"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Café"
           }
         }
       }
@@ -780,6 +876,12 @@
             "state" : "translated",
             "value" : "齒輪"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Engranaje"
+          }
         }
       }
     },
@@ -825,6 +927,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "柯基"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Welsh Corgi"
           }
         }
       }
@@ -872,6 +980,12 @@
             "state" : "translated",
             "value" : "牛頓球"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Péndulo de Newton"
+          }
         }
       }
     },
@@ -917,6 +1031,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正弦曲線"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Curva sinusoidal"
           }
         }
       }
@@ -964,6 +1084,12 @@
             "state" : "translated",
             "value" : "恐龍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinosaurio"
+          }
         }
       }
     },
@@ -1009,6 +1135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "狗"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Perro"
           }
         }
       }
@@ -1056,6 +1188,12 @@
             "state" : "translated",
             "value" : "日式道歉"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disculpa japonesa"
+          }
         }
       }
     },
@@ -1101,6 +1239,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "海豚"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delfín"
           }
         }
       }
@@ -1148,6 +1292,12 @@
             "state" : "translated",
             "value" : "點點"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puntos"
+          }
         }
       }
     },
@@ -1193,6 +1343,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "龍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dragón"
           }
         }
       }
@@ -1240,6 +1396,12 @@
             "state" : "translated",
             "value" : "珍珠奶茶"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bebida de tapioca"
+          }
         }
       }
     },
@@ -1285,6 +1447,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "水滴"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gota"
           }
         }
       }
@@ -1332,6 +1500,12 @@
             "state" : "translated",
             "value" : "橡皮鴨"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pato de goma"
+          }
         }
       }
     },
@@ -1377,6 +1551,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "地球"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tierra"
           }
         }
       }
@@ -1424,6 +1604,12 @@
             "state" : "translated",
             "value" : "引擎"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Motor"
+          }
         }
       }
     },
@@ -1465,7 +1651,7 @@
             "value" : "Entaku"
           }
         },
-        "zh-Hant" : {
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Entaku"
@@ -1516,6 +1702,12 @@
             "state" : "translated",
             "value" : "工廠"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fábrica"
+          }
         }
       }
     },
@@ -1561,6 +1753,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "魚人"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hombre-pez"
           }
         }
       }
@@ -1608,6 +1806,12 @@
             "state" : "translated",
             "value" : "狐狸"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zorro"
+          }
         }
       }
     },
@@ -1653,6 +1857,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "青蛙"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rana"
           }
         }
       }
@@ -1700,6 +1910,12 @@
             "state" : "translated",
             "value" : "平底鍋"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sartén"
+          }
         }
       }
     },
@@ -1745,6 +1961,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "幽靈"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fantasma"
           }
         }
       }
@@ -1792,6 +2014,12 @@
             "state" : "translated",
             "value" : "灰狗"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Galgo"
+          }
         }
       }
     },
@@ -1837,6 +2065,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刺蝟"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erizo"
           }
         }
       }
@@ -1884,6 +2118,12 @@
             "state" : "translated",
             "value" : "馬"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caballo"
+          }
         }
       }
     },
@@ -1929,6 +2169,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "人"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Humano"
           }
         }
       }
@@ -1976,6 +2222,12 @@
             "state" : "translated",
             "value" : "南瓜燈"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calabaza de Halloween"
+          }
         }
       }
     },
@@ -2021,6 +2273,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "蒸汽火車"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Locomotora de vapor"
           }
         }
       }
@@ -2068,6 +2326,12 @@
             "state" : "translated",
             "value" : "自製跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredor personalizado"
+          }
         }
       }
     },
@@ -2113,6 +2377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "麻糬"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mochi"
           }
         }
       }
@@ -2160,6 +2430,12 @@
             "state" : "translated",
             "value" : "老鼠"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ratón"
+          }
         }
       }
     },
@@ -2205,6 +2481,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "招財貓"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maneki Neko"
           }
         }
       }
@@ -2252,6 +2534,12 @@
             "state" : "translated",
             "value" : "章魚"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulpo"
+          }
         }
       }
     },
@@ -2297,6 +2585,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "水獺"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nutria"
           }
         }
       }
@@ -2344,6 +2638,12 @@
             "state" : "translated",
             "value" : "貓頭鷹"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Búho"
+          }
         }
       }
     },
@@ -2389,6 +2689,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "鸚鵡"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loro"
           }
         }
       }
@@ -2436,6 +2742,12 @@
             "state" : "translated",
             "value" : "鐘擺"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Péndulo"
+          }
         }
       }
     },
@@ -2481,6 +2793,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "企鵝"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pingüino"
           }
         }
       }
@@ -2528,6 +2846,12 @@
             "state" : "translated",
             "value" : "企鵝 2"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pingüino 2"
+          }
         }
       }
     },
@@ -2573,6 +2897,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "派對中的人們"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gente de fiesta"
           }
         }
       }
@@ -2620,6 +2950,12 @@
             "state" : "translated",
             "value" : "小豬"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerdo"
+          }
         }
       }
     },
@@ -2665,6 +3001,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "心跳"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulso"
           }
         }
       }
@@ -2712,6 +3054,12 @@
             "state" : "translated",
             "value" : "小狗"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cachorro"
+          }
         }
       }
     },
@@ -2757,6 +3105,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "小兔子"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conejo"
           }
         }
       }
@@ -2804,6 +3158,12 @@
             "state" : "translated",
             "value" : "反應爐"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reactor"
+          }
         }
       }
     },
@@ -2849,6 +3209,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "火箭"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cohete"
           }
         }
       }
@@ -2896,6 +3262,12 @@
             "state" : "translated",
             "value" : "解鎖所有跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desbloquear todos los corredores"
+          }
         }
       }
     },
@@ -2941,6 +3313,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "香腸"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salchicha"
           }
         }
       }
@@ -2988,6 +3366,12 @@
             "state" : "translated",
             "value" : "綿羊"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oveja"
+          }
         }
       }
     },
@@ -3033,6 +3417,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "馴鹿與雪橇"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reno y trineo"
           }
         }
       }
@@ -3080,6 +3470,12 @@
             "state" : "translated",
             "value" : "史萊姆"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slime"
+          }
         }
       }
     },
@@ -3125,6 +3521,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "雪人"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muñeco de nieve"
           }
         }
       }
@@ -3172,6 +3574,12 @@
             "state" : "translated",
             "value" : "仙女棒"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bengala"
+          }
         }
       }
     },
@@ -3217,6 +3625,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "松鼠"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ardilla"
           }
         }
       }
@@ -3264,6 +3678,12 @@
             "state" : "translated",
             "value" : "壽司"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sushi"
+          }
         }
       }
     },
@@ -3309,6 +3729,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "迴轉壽司"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sushi giratorio"
           }
         }
       }
@@ -3356,6 +3782,12 @@
             "state" : "translated",
             "value" : "貓尾巴"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cola de gato"
+          }
         }
       }
     },
@@ -3401,6 +3833,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "梗犬"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terrier"
           }
         }
       }
@@ -3448,6 +3886,12 @@
             "state" : "translated",
             "value" : "力量，智慧，勇氣"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuerza, Sabiduría, Valor"
+          }
         }
       }
     },
@@ -3489,7 +3933,7 @@
             "value" : "Uhooi"
           }
         },
-        "zh-Hant" : {
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uhooi"
@@ -3540,6 +3984,12 @@
             "state" : "translated",
             "value" : "伏地挺身"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flexión"
+          }
         }
       }
     },
@@ -3585,6 +4035,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "仰臥起坐"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abdominal"
           }
         }
       }
@@ -3632,6 +4088,12 @@
             "state" : "translated",
             "value" : "鯨魚"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ballena"
+          }
         }
       }
     },
@@ -3677,6 +4139,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "倉鼠跑輪子"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rueda de hámster"
           }
         }
       }

--- a/Sources/RunCatLocalization/Resources/RunnersStore.xcstrings
+++ b/Sources/RunCatLocalization/Resources/RunnersStore.xcstrings
@@ -1,1202 +1,1064 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "categoryAnimal": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tierische Läufer"
+  "sourceLanguage" : "en",
+  "strings" : {
+    "categoryAnimal" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tierische Läufer"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Animal type runners"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Animal type runners"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coureurs animaux"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coureurs animaux"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "生物系ランナー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生物系ランナー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "동물 러너"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "동물 러너"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "动物类跑者"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "动物类跑者"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "動物類跑者"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Animal type corredors"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動物類跑者"
           }
         }
       }
     },
-    "categoryInanimate": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unbelebte Läufer"
+    "categoryInanimate" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unbelebte Läufer"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inanimate type runners"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inanimate type runners"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coureurs objets"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coureurs objets"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "非生物系ランナー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非生物系ランナー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "무생물 러너"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "무생물 러너"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "非生物类跑者"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非生物类跑者"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "非生物類跑者"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inanimate type corredors"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非生物類跑者"
           }
         }
       }
     },
-    "categoryRecommended": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Empfohlene Elemente"
+    "categoryRecommended" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empfohlene Elemente"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recommended items"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recommended items"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Catégories recommandées"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catégories recommandées"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "おすすめ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "おすすめ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "추천 아이템"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추천 아이템"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "推荐项目"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推荐项目"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "推薦項目"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recommended items"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推薦項目"
           }
         }
       }
     },
-    "categorySeasonal": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Saisonale Läufer"
+    "categorySeasonal" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saisonale Läufer"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seasonal runners"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seasonal runners"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coureur de saison"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coureur de saison"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "季節のランナー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "季節のランナー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "계절한정 러너"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계절한정 러너"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "季节限定跑者"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "季节限定跑者"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "季節限定跑者"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seasonal corredors"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "季節限定跑者"
           }
         }
       }
     },
-    "categorySpecial": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Läufer in Sonderfarben (unterstützen Sie den Entwickler)"
+    "categorySpecial" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Läufer in Sonderfarben (unterstützen Sie den Entwickler)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Special-colored runners (support the developer)"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Special-colored runners (support the developer)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coureurs édition colorée (soutient le développeur)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coureurs édition colorée (soutient le développeur)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "特別カラー版ランナー（開発者への支援）"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "特別カラー版ランナー（開発者への支援）"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "특별 컬러 러너 (개발자 도네이션)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "특별 컬러 러너 (개발자 도네이션)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "特殊配色跑者（支持开发者）"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "特殊配色跑者（支持开发者）"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "特殊配色跑者（支持開發者）"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Special-colored corredors (support the developer)"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "特殊配色跑者（支持開發者）"
           }
         }
       }
     },
-    "failedToSync": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fehler beim Synchronisieren mit dem AppStore."
+    "failedToSync" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fehler beim Synchronisieren mit dem AppStore."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to sync with AppStore."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to sync with AppStore."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erreur de synchronisation avec l’AppStore."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreur de synchronisation avec l’AppStore."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AppStoreとの同期に失敗しました。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AppStoreとの同期に失敗しました。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AppStore와 동기화하는 데 실패했습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AppStore와 동기화하는 데 실패했습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "与 App Store 同步失败。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "与 App Store 同步失败。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "與 App Store 同步失敗。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to sync with AppStore."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "與 App Store 同步失敗。"
           }
         }
       }
     },
-    "failedToVerify": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Transaktionsdatensignatur ist ungültig."
+    "failedToVerify" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Transaktionsdatensignatur ist ungültig."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The transaction data signature is invalid."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The transaction data signature is invalid."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La signature des données de transaction est invalide."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La signature des données de transaction est invalide."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "トランザクションデータの署名が不正です。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トランザクションデータの署名が不正です。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "잘못된 트랜잭션 데이터 서명입니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잘못된 트랜잭션 데이터 서명입니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "交易数据签名无效。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "交易数据签名无效。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "交易資料簽名無效。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The transaction data signature is invalid."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "交易資料簽名無效。"
           }
         }
       }
     },
-    "noAvailableItems": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keine verfügbaren Elemente"
+    "noAvailableItems" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine verfügbaren Elemente"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Available Items"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Available Items"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pas d’articles disponibles"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas d’articles disponibles"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "利用可能なアイテムなし"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用可能なアイテムなし"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사용 가능한 항목이 없음"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용 가능한 항목이 없음"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "暂无可用项目"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无可用项目"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "沒有可用項目"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Available Items"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有可用項目"
           }
         }
       }
     },
-    "noAvailableItemsSuggestion": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Für die Nutzung von Runners Store ist eine Internetverbindung erforderlich.\nBitte überprüfen Sie Ihre Internetverbindung."
+    "noAvailableItemsSuggestion" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Für die Nutzung von Runners Store ist eine Internetverbindung erforderlich.\nBitte überprüfen Sie Ihre Internetverbindung."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An internet connection is required to use Runners Store.\nPlease check your internet connection."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An internet connection is required to use Runners Store.\nPlease check your internet connection."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Une connexion internet est requise pour utiliser le Magasin de Coureurs.\nVérifiez votre connexion internet."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une connexion internet est requise pour utiliser le Magasin de Coureurs.\nVérifiez votre connexion internet."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Runners Storeの利用にはインターネット接続が必要です。\nインターネット接続を確認してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Runners Storeの利用にはインターネット接続が必要です。\nインターネット接続を確認してください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Runners Store를 사용하려면 인터넷 연결이 필요합니다.\n인터넷 연결을 확인해주세요."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Runners Store를 사용하려면 인터넷 연결이 필요합니다.\n인터넷 연결을 확인해주세요."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "访问跑者商店需要联网，请检查你的网络连接。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "访问跑者商店需要联网，请检查你的网络连接。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "查看跑者商店需要網路連線，請檢查你的網路連線狀況。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An internet connection is required to use Corredors Store.\nPlease check your internet connection."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看跑者商店需要網路連線，請檢查你的網路連線狀況。"
           }
         }
       }
     },
-    "pending": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der Kauf steht noch aus."
+    "pending" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Kauf steht noch aus."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The purchase is pending."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The purchase is pending."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La transaction est en attente."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La transaction est en attente."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "購入が保留されています。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購入が保留されています。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "구매가 진행중입니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "구매가 진행중입니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "购买正在处理中。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "购买正在处理中。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "交易處理中。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The purchase is pending."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "交易處理中。"
           }
         }
       }
     },
-    "productNotFound": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dieses Produkt wurde nicht gefunden."
+    "productNotFound" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieses Produkt wurde nicht gefunden."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This product is not found."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This product is not found."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ce produit est introuvable."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce produit est introuvable."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "商品が見つかりませんでした。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "商品が見つかりませんでした。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이 상품을 찾을 수 없습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 상품을 찾을 수 없습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未找到该商品。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到该商品。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "找不到該商品。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This product is not found."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到該商品。"
           }
         }
       }
     },
-    "productNotFoundSuggestion": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Starten Sie die Anwendung neu, während Sie mit dem Netzwerk verbunden sind."
+    "productNotFoundSuggestion" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starten Sie die Anwendung neu, während Sie mit dem Netzwerk verbunden sind."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restart the application while connected to the network."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restart the application while connected to the network."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redémarrer l’application une fois connecté à internet."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redémarrer l’application une fois connecté à internet."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワークに繋がった環境でアプリを再起動してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネットワークに繋がった環境でアプリを再起動してください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "네트워크 상태를 확인하신 뒤, 애플리케이션을 재시작 해주세요."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "네트워크 상태를 확인하신 뒤, 애플리케이션을 재시작 해주세요."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "请在联网状态下重新启动应用。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请在联网状态下重新启动应用。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "請在有網路連線的狀態下重新啟動 App。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restart the application while connected to the network."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請在有網路連線的狀態下重新啟動 App。"
           }
         }
       }
     },
-    "productUnavailable": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dieses Produkt ist nicht verfügbar."
+    "productUnavailable" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieses Produkt ist nicht verfügbar."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This product is unavaliable."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This product is unavaliable."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ce produit est indisponible."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce produit est indisponible."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "商品が無効です。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "商品が無効です。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이 상품은 현재 사용이 불가능합니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 상품은 현재 사용이 불가능합니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "该商品当前不可用。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该商品当前不可用。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "該商品不可用。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This product is unavaliable."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該商品不可用。"
           }
         }
       }
     },
-    "purchase": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kauf"
+    "purchase" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kauf"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Purchase"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Purchase"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acheter"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acheter"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "購入"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購入"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "구매"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "구매"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "购买"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "购买"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "購買"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Purchase"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購買"
           }
         }
       }
     },
-    "purchaseErrorTitle": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kauffehler"
+    "purchaseErrorTitle" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kauffehler"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Purchasing Error"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Purchasing Error"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erreur lors de l’achat"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreur lors de l’achat"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "購入エラー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購入エラー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "구매 오류"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "구매 오류"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "购买出错"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "购买出错"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "交易失敗"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Purchasing Error"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "交易失敗"
           }
         }
       }
     },
-    "purchaseNotAllowed": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der Kauf ist nicht erlaubt."
+    "purchaseNotAllowed" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Kauf ist nicht erlaubt."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The purchase is not allowed."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The purchase is not allowed."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "L’achat n’est pas autorisé."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’achat n’est pas autorisé."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "支払い機能が無効化されています。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支払い機能が無効化されています。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이 구매는 불가능합니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 구매는 불가능합니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法进行购买"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法进行购买"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "無法進行交易。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The purchase is not allowed."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法進行交易。"
           }
         }
       }
     },
-    "purchaseNotAllowedSuggestion": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Überprüfen Sie die Zahlungseinstellungen Ihrer Apple ID."
+    "purchaseNotAllowedSuggestion" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Überprüfen Sie die Zahlungseinstellungen Ihrer Apple ID."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check your Apple ID payment settings."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check your Apple ID payment settings."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vérifiez vos réglages de paiement de l’identifiant Apple."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérifiez vos réglages de paiement de l’identifiant Apple."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apple IDの支払いに関する設定を見直してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple IDの支払いに関する設定を見直してください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apple ID 결제 방법을 확인해주세요."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple ID 결제 방법을 확인해주세요."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "请检查你的 Apple ID 支付设置。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请检查你的 Apple ID 支付设置。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "請檢查你的 Apple ID 付款設定。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check your Apple ID payment settings."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請檢查你的 Apple ID 付款設定。"
           }
         }
       }
     },
-    "reload": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Neu laden"
+    "reload" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neu laden"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reload"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reload"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Recharger"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recharger"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "再読み込み"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再読み込み"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "재로드"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재로드"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "刷新"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重新載入"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reload"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新載入"
           }
         }
       }
     },
-    "restore": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wiederherstellen"
+    "restore" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiederherstellen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rétablir"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rétablir"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "復元"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復元"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "복구"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복구"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "恢复购买"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复购买"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "恢復購買"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢復購買"
           }
         }
       }
     },
-    "restoreTitle": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wiederherstellung basierend auf Verlauf"
+    "restoreTitle" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiederherstellung basierend auf Verlauf"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore based on history"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore based on history"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restauration basée sur l’historique"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restauration basée sur l’historique"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "購入履歴から復元"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購入履歴から復元"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "구매이력으로 복구"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "구매이력으로 복구"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "根据历史记录恢复"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "根据历史记录恢复"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "根據歷史紀錄恢復"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore based on history"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "根據歷史紀錄恢復"
           }
         }
       }
     },
-    "runnersStoreTitle": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Läufer Store"
+    "runnersStoreTitle" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Läufer Store"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Runners Store"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Runners Store"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Magasin de Coureurs"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Magasin de Coureurs"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ランナーストア"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ランナーストア"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "러너 스토어"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "러너 스토어"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "跑者商店"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跑者商店"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "跑者商店"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Corredors Store"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跑者商店"
           }
         }
       }
     },
-    "unknownError": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unbekannter Fehler aufgetreten."
+    "unknownError" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unbekannter Fehler aufgetreten."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown error occurred."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unknown error occurred."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Une erreur inattendue s’est produite."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une erreur inattendue s’est produite."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不明なエラーが発生しました。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不明なエラーが発生しました。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "알수없는 오류가 발생했습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알수없는 오류가 발생했습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "发生未知错误。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发生未知错误。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "發生未知的錯誤。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown error occurred."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "發生未知的錯誤。"
           }
         }
       }
     },
-    "userCancelled": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Der Kauf wurde storniert."
+    "userCancelled" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Kauf wurde storniert."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The purchase was cancelled."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The purchase was cancelled."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "L’achat a été annulé."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’achat a été annulé."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "購入がキャンセルされました。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "購入がキャンセルされました。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "구매가 취소되었습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "구매가 취소되었습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已取消购买。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已取消购买。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此交易被取消。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The purchase was cancelled."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此交易被取消。"
           }
         }
       }
     }
   },
-  "version": "1.0"
+  "version" : "1.0"
 }

--- a/Sources/RunCatLocalization/Resources/RunnersStore.xcstrings
+++ b/Sources/RunCatLocalization/Resources/RunnersStore.xcstrings
@@ -44,6 +44,12 @@
             "state" : "translated",
             "value" : "動物類跑者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores de tipo animal"
+          }
         }
       }
     },
@@ -89,6 +95,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "非生物類跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores de tipo inanimado"
           }
         }
       }
@@ -136,6 +148,12 @@
             "state" : "translated",
             "value" : "推薦項目"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elementos recomendados"
+          }
         }
       }
     },
@@ -181,6 +199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "季節限定跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores estacionales"
           }
         }
       }
@@ -228,6 +252,12 @@
             "state" : "translated",
             "value" : "特殊配色跑者（支持開發者）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores de colores especiales"
+          }
         }
       }
     },
@@ -273,6 +303,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "與 App Store 同步失敗。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al sincronizar con App Store."
           }
         }
       }
@@ -320,6 +356,12 @@
             "state" : "translated",
             "value" : "交易資料簽名無效。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La firma de los datos de la transacción no es válida."
+          }
         }
       }
     },
@@ -365,6 +407,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "沒有可用項目"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay elementos disponibles"
           }
         }
       }
@@ -412,6 +460,12 @@
             "state" : "translated",
             "value" : "查看跑者商店需要網路連線，請檢查你的網路連線狀況。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se requiere una conexión a internet para usar la Tienda de Corredores.\nPor favor, verifica tu conexión a internet."
+          }
         }
       }
     },
@@ -457,6 +511,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "交易處理中。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La compra está pendiente."
           }
         }
       }
@@ -504,6 +564,12 @@
             "state" : "translated",
             "value" : "找不到該商品。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este producto no se encontró."
+          }
         }
       }
     },
@@ -549,6 +615,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "請在有網路連線的狀態下重新啟動 App。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reinicia la aplicación mientras estés conectado a la red."
           }
         }
       }
@@ -596,6 +668,12 @@
             "state" : "translated",
             "value" : "該商品不可用。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este producto no está disponible."
+          }
         }
       }
     },
@@ -641,6 +719,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "購買"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprar"
           }
         }
       }
@@ -688,6 +772,12 @@
             "state" : "translated",
             "value" : "交易失敗"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error de compra"
+          }
         }
       }
     },
@@ -733,6 +823,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無法進行交易。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La compra no está permitida."
           }
         }
       }
@@ -780,6 +876,12 @@
             "state" : "translated",
             "value" : "請檢查你的 Apple ID 付款設定。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revisa la configuración de pago de tu Apple ID."
+          }
         }
       }
     },
@@ -825,6 +927,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新載入"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recargar"
           }
         }
       }
@@ -872,6 +980,12 @@
             "state" : "translated",
             "value" : "恢復購買"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurar"
+          }
         }
       }
     },
@@ -917,6 +1031,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "根據歷史紀錄恢復"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurar según el historial"
           }
         }
       }
@@ -964,6 +1084,12 @@
             "state" : "translated",
             "value" : "跑者商店"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tienda de Corredores"
+          }
         }
       }
     },
@@ -1010,6 +1136,12 @@
             "state" : "translated",
             "value" : "發生未知的錯誤。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocurrió un error desconocido."
+          }
         }
       }
     },
@@ -1055,6 +1187,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此交易被取消。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La compra fue cancelada."
           }
         }
       }

--- a/Sources/RunCatLocalization/Resources/RunnersStore.xcstrings
+++ b/Sources/RunCatLocalization/Resources/RunnersStore.xcstrings
@@ -1,1064 +1,1202 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "categoryAnimal" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tierische Läufer"
+  "sourceLanguage": "en",
+  "strings": {
+    "categoryAnimal": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tierische Läufer"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Animal type runners"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Animal type runners"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coureurs animaux"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coureurs animaux"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "生物系ランナー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生物系ランナー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "동물 러너"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "동물 러너"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "动物类跑者"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "动物类跑者"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "動物類跑者"
-          }
-        }
-      }
-    },
-    "categoryInanimate" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbelebte Läufer"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "動物類跑者"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inanimate type runners"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coureurs objets"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "非生物系ランナー"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "무생물 러너"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "非生物类跑者"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "非生物類跑者"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Animal type corredors"
           }
         }
       }
     },
-    "categoryRecommended" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empfohlene Elemente"
+    "categoryInanimate": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbelebte Läufer"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recommended items"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inanimate type runners"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Catégories recommandées"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coureurs objets"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "おすすめ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非生物系ランナー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "추천 아이템"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "무생물 러너"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "推荐项目"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非生物类跑者"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "推薦項目"
-          }
-        }
-      }
-    },
-    "categorySeasonal" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saisonale Läufer"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "非生物類跑者"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seasonal runners"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coureur de saison"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "季節のランナー"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "계절한정 러너"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "季节限定跑者"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "季節限定跑者"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inanimate type corredors"
           }
         }
       }
     },
-    "categorySpecial" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Läufer in Sonderfarben (unterstützen Sie den Entwickler)"
+    "categoryRecommended": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empfohlene Elemente"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Special-colored runners (support the developer)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recommended items"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coureurs édition colorée (soutient le développeur)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Catégories recommandées"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "特別カラー版ランナー（開発者への支援）"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "おすすめ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "특별 컬러 러너 (개발자 도네이션)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추천 아이템"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "特殊配色跑者（支持开发者）"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "推荐项目"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "特殊配色跑者（支持開發者）"
-          }
-        }
-      }
-    },
-    "failedToSync" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler beim Synchronisieren mit dem AppStore."
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "推薦項目"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to sync with AppStore."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur de synchronisation avec l’AppStore."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AppStoreとの同期に失敗しました。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AppStore와 동기화하는 데 실패했습니다."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "与 App Store 同步失败。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "與 App Store 同步失敗。"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recommended items"
           }
         }
       }
     },
-    "failedToVerify" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Transaktionsdatensignatur ist ungültig."
+    "categorySeasonal": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saisonale Läufer"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The transaction data signature is invalid."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seasonal runners"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La signature des données de transaction est invalide."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coureur de saison"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "トランザクションデータの署名が不正です。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "季節のランナー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "잘못된 트랜잭션 데이터 서명입니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계절한정 러너"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "交易数据签名无效。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "季节限定跑者"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "交易資料簽名無效。"
-          }
-        }
-      }
-    },
-    "noAvailableItems" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine verfügbaren Elemente"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "季節限定跑者"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Available Items"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pas d’articles disponibles"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "利用可能なアイテムなし"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사용 가능한 항목이 없음"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暂无可用项目"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "沒有可用項目"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seasonal corredors"
           }
         }
       }
     },
-    "noAvailableItemsSuggestion" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Für die Nutzung von Runners Store ist eine Internetverbindung erforderlich.\nBitte überprüfen Sie Ihre Internetverbindung."
+    "categorySpecial": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läufer in Sonderfarben (unterstützen Sie den Entwickler)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "An internet connection is required to use Runners Store.\nPlease check your internet connection."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Special-colored runners (support the developer)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Une connexion internet est requise pour utiliser le Magasin de Coureurs.\nVérifiez votre connexion internet."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coureurs édition colorée (soutient le développeur)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Runners Storeの利用にはインターネット接続が必要です。\nインターネット接続を確認してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "特別カラー版ランナー（開発者への支援）"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Runners Store를 사용하려면 인터넷 연결이 필요합니다.\n인터넷 연결을 확인해주세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "특별 컬러 러너 (개발자 도네이션)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "访问跑者商店需要联网，请检查你的网络连接。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "特殊配色跑者（支持开发者）"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "查看跑者商店需要網路連線，請檢查你的網路連線狀況。"
-          }
-        }
-      }
-    },
-    "pending" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Kauf steht noch aus."
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "特殊配色跑者（支持開發者）"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The purchase is pending."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La transaction est en attente."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "購入が保留されています。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "구매가 진행중입니다."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "购买正在处理中。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "交易處理中。"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Special-colored corredors (support the developer)"
           }
         }
       }
     },
-    "productNotFound" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Produkt wurde nicht gefunden."
+    "failedToSync": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler beim Synchronisieren mit dem AppStore."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This product is not found."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to sync with AppStore."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ce produit est introuvable."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur de synchronisation avec l’AppStore."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "商品が見つかりませんでした。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AppStoreとの同期に失敗しました。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 상품을 찾을 수 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AppStore와 동기화하는 데 실패했습니다."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未找到该商品。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "与 App Store 同步失败。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "找不到該商品。"
-          }
-        }
-      }
-    },
-    "productNotFoundSuggestion" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starten Sie die Anwendung neu, während Sie mit dem Netzwerk verbunden sind."
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "與 App Store 同步失敗。"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restart the application while connected to the network."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redémarrer l’application une fois connecté à internet."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ネットワークに繋がった環境でアプリを再起動してください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "네트워크 상태를 확인하신 뒤, 애플리케이션을 재시작 해주세요."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请在联网状态下重新启动应用。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "請在有網路連線的狀態下重新啟動 App。"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to sync with AppStore."
           }
         }
       }
     },
-    "productUnavailable" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Produkt ist nicht verfügbar."
+    "failedToVerify": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Transaktionsdatensignatur ist ungültig."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This product is unavaliable."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The transaction data signature is invalid."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ce produit est indisponible."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La signature des données de transaction est invalide."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "商品が無効です。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トランザクションデータの署名が不正です。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 상품은 현재 사용이 불가능합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "잘못된 트랜잭션 데이터 서명입니다."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "该商品当前不可用。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "交易数据签名无效。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "該商品不可用。"
-          }
-        }
-      }
-    },
-    "purchase" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kauf"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "交易資料簽名無效。"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Purchase"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acheter"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "購入"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "구매"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "购买"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "購買"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The transaction data signature is invalid."
           }
         }
       }
     },
-    "purchaseErrorTitle" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kauffehler"
+    "noAvailableItems": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine verfügbaren Elemente"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Purchasing Error"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Available Items"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur lors de l’achat"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas d’articles disponibles"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "購入エラー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能なアイテムなし"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "구매 오류"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 가능한 항목이 없음"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "购买出错"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无可用项目"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "交易失敗"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有可用項目"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Available Items"
           }
         }
       }
     },
-    "purchaseNotAllowed" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Kauf ist nicht erlaubt."
+    "noAvailableItemsSuggestion": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für die Nutzung von Runners Store ist eine Internetverbindung erforderlich.\nBitte überprüfen Sie Ihre Internetverbindung."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The purchase is not allowed."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An internet connection is required to use Runners Store.\nPlease check your internet connection."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L’achat n’est pas autorisé."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une connexion internet est requise pour utiliser le Magasin de Coureurs.\nVérifiez votre connexion internet."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "支払い機能が無効化されています。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runners Storeの利用にはインターネット接続が必要です。\nインターネット接続を確認してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 구매는 불가능합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runners Store를 사용하려면 인터넷 연결이 필요합니다.\n인터넷 연결을 확인해주세요."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法进行购买"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "访问跑者商店需要联网，请检查你的网络连接。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法進行交易。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看跑者商店需要網路連線，請檢查你的網路連線狀況。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An internet connection is required to use Corredors Store.\nPlease check your internet connection."
           }
         }
       }
     },
-    "purchaseNotAllowedSuggestion" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überprüfen Sie die Zahlungseinstellungen Ihrer Apple ID."
+    "pending": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Kauf steht noch aus."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check your Apple ID payment settings."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The purchase is pending."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifiez vos réglages de paiement de l’identifiant Apple."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La transaction est en attente."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple IDの支払いに関する設定を見直してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "購入が保留されています。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple ID 결제 방법을 확인해주세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구매가 진행중입니다."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请检查你的 Apple ID 支付设置。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "购买正在处理中。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "請檢查你的 Apple ID 付款設定。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "交易處理中。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The purchase is pending."
           }
         }
       }
     },
-    "reload" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neu laden"
+    "productNotFound": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Produkt wurde nicht gefunden."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reload"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This product is not found."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recharger"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce produit est introuvable."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再読み込み"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "商品が見つかりませんでした。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "재로드"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 상품을 찾을 수 없습니다."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "刷新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到该商品。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新載入"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到該商品。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This product is not found."
           }
         }
       }
     },
-    "restore" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiederherstellen"
+    "productNotFoundSuggestion": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten Sie die Anwendung neu, während Sie mit dem Netzwerk verbunden sind."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restore"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart the application while connected to the network."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rétablir"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redémarrer l’application une fois connecté à internet."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "復元"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワークに繋がった環境でアプリを再起動してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "복구"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "네트워크 상태를 확인하신 뒤, 애플리케이션을 재시작 해주세요."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "恢复购买"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请在联网状态下重新启动应用。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "恢復購買"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請在有網路連線的狀態下重新啟動 App。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart the application while connected to the network."
           }
         }
       }
     },
-    "restoreTitle" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiederherstellung basierend auf Verlauf"
+    "productUnavailable": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Produkt ist nicht verfügbar."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restore based on history"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This product is unavaliable."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restauration basée sur l’historique"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce produit est indisponible."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "購入履歴から復元"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "商品が無効です。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "구매이력으로 복구"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 상품은 현재 사용이 불가능합니다."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "根据历史记录恢复"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该商品当前不可用。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "根據歷史紀錄恢復"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "該商品不可用。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This product is unavaliable."
           }
         }
       }
     },
-    "runnersStoreTitle" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Läufer Store"
+    "purchase": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kauf"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Runners Store"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Purchase"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Magasin de Coureurs"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acheter"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ランナーストア"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "購入"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "러너 스토어"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구매"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跑者商店"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "购买"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跑者商店"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "購買"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Purchase"
           }
         }
       }
     },
-    "unknownError" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbekannter Fehler aufgetreten."
+    "purchaseErrorTitle": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kauffehler"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unknown error occurred."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Purchasing Error"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Une erreur inattendue s’est produite."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur lors de l’achat"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不明なエラーが発生しました。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "購入エラー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "알수없는 오류가 발생했습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구매 오류"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "发生未知错误。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "购买出错"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "發生未知的錯誤。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "交易失敗"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Purchasing Error"
           }
         }
       }
     },
-    "userCancelled" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Kauf wurde storniert."
+    "purchaseNotAllowed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Kauf ist nicht erlaubt."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The purchase was cancelled."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The purchase is not allowed."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L’achat a été annulé."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’achat n’est pas autorisé."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "購入がキャンセルされました。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支払い機能が無効化されています。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "구매가 취소되었습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 구매는 불가능합니다."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已取消购买。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法进行购买"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此交易被取消。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法進行交易。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The purchase is not allowed."
+          }
+        }
+      }
+    },
+    "purchaseNotAllowedSuggestion": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfen Sie die Zahlungseinstellungen Ihrer Apple ID."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check your Apple ID payment settings."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifiez vos réglages de paiement de l’identifiant Apple."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple IDの支払いに関する設定を見直してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple ID 결제 방법을 확인해주세요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请检查你的 Apple ID 支付设置。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請檢查你的 Apple ID 付款設定。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check your Apple ID payment settings."
+          }
+        }
+      }
+    },
+    "reload": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neu laden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reload"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recharger"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再読み込み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "재로드"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新載入"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reload"
+          }
+        }
+      }
+    },
+    "restore": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederherstellen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rétablir"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "復元"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복구"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复购买"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復購買"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore"
+          }
+        }
+      }
+    },
+    "restoreTitle": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiederherstellung basierend auf Verlauf"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore based on history"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restauration basée sur l’historique"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "購入履歴から復元"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구매이력으로 복구"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "根据历史记录恢复"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "根據歷史紀錄恢復"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore based on history"
+          }
+        }
+      }
+    },
+    "runnersStoreTitle": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läufer Store"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runners Store"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Magasin de Coureurs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ランナーストア"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "러너 스토어"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跑者商店"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跑者商店"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corredors Store"
+          }
+        }
+      }
+    },
+    "unknownError": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannter Fehler aufgetreten."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown error occurred."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une erreur inattendue s’est produite."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明なエラーが発生しました。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알수없는 오류가 발생했습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发生未知错误。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "發生未知的錯誤。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown error occurred."
+          }
+        }
+      }
+    },
+    "userCancelled": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Kauf wurde storniert."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The purchase was cancelled."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’achat a été annulé."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "購入がキャンセルされました。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구매가 취소되었습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已取消购买。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此交易被取消。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The purchase was cancelled."
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/Sources/RunCatLocalization/Resources/RunnersStore.xcstrings
+++ b/Sources/RunCatLocalization/Resources/RunnersStore.xcstrings
@@ -256,7 +256,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Corredores de colores especiales"
+            "value" : "Corredores de colores especiales (apoya al desarrollador)"
           }
         }
       }

--- a/Sources/RunCatLocalization/Resources/SelfMadeRunners.xcstrings
+++ b/Sources/RunCatLocalization/Resources/SelfMadeRunners.xcstrings
@@ -1,998 +1,884 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "add": {
-      "generatesSymbol": false,
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hinzufügen"
+  "sourceLanguage" : "en",
+  "strings" : {
+    "add" : {
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hinzufügen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajouter"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "追加"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "추가"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추가"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "添加"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "添加"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加"
           }
         }
       }
     },
-    "addedRunners": {
-      "generatesSymbol": false,
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hinzugefügte Läufer:"
+    "addedRunners" : {
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hinzugefügte Läufer:"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Added Runners:"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Added Runners:"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coureurs ajoutés :"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coureurs ajoutés :"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "追加済みのランナー："
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加済みのランナー："
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "추가된 러너:"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추가된 러너:"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已添加的跑者："
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已添加的跑者："
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已添加的跑者："
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Added Corredors:"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已添加的跑者："
           }
         }
       }
     },
-    "addErrorTitle": {
-      "generatesSymbol": false,
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hinzufügungsfehler"
+    "addErrorTitle" : {
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hinzufügungsfehler"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Addition Error"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Addition Error"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erreur lors de l'ajout"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreur lors de l'ajout"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ランナー追加エラー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ランナー追加エラー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "추가 오류"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추가 오류"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无法添加"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法添加"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "添加失敗"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Addition Error"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加失敗"
           }
         }
       }
     },
-    "color": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Farbe:"
+    "color" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Farbe:"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Color:"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Color:"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couleur :"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couleur :"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "色："
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "色："
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "색상:"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "색상:"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "颜色："
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "颜色："
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "顏色："
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Color:"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顏色："
           }
         }
       }
     },
-    "conflictName": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dieser Läufername wird bereits verwendet."
+    "conflictName" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Läufername wird bereits verwendet."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This runner name is already in use."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This runner name is already in use."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ce nom de coureur est déjà utilisé."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce nom de coureur est déjà utilisé."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この名前はすでに使用されています。別の名前を使用してください。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この名前はすでに使用されています。別の名前を使用してください。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이미 사용중인 러너 이름입니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미 사용중인 러너 이름입니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "该跑者名称已被使用。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该跑者名称已被使用。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "此跑者名稱已被使用。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This corredor name is already in use."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此跑者名稱已被使用。"
           }
         }
       }
     },
-    "failedToEncodeImages": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fehler beim Encodieren der Bilder."
+    "failedToEncodeImages" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fehler beim Encodieren der Bilder."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to encode images."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to encode images."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "L’encodage de l’image a échoué."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’encodage de l’image a échoué."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "画像のエンコードに失敗しました。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像のエンコードに失敗しました。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이미지를 인코딩하지 못했습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미지를 인코딩하지 못했습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "图片编码失败。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图片编码失败。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "編碼圖片失敗。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to encode images."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編碼圖片失敗。"
           }
         }
       }
     },
-    "failedToSave": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fehler beim Speichern des selbsterstellten Läufers."
+    "failedToSave" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fehler beim Speichern des selbsterstellten Läufers."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to save the self-made runner."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to save the self-made runner."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "L’enregistrement du coureur personnalisé a échoué."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’enregistrement du coureur personnalisé a échoué."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自作ランナーの保存に失敗しました。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自作ランナーの保存に失敗しました。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "커스텀 러너 저장에 실패했습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커스텀 러너 저장에 실패했습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保存自制跑者失败。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存自制跑者失败。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "儲存自製跑者失敗。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to save the self-made corredor."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存自製跑者失敗。"
           }
         }
       }
     },
-    "formatRequirement": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. Format: PNG"
+    "formatRequirement" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. Format: PNG"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. Format: PNG"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. Format: PNG"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. Format : PNG"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. Format : PNG"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. フォーマット：PNG"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. フォーマット：PNG"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. 파일 형식: PNG"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. 파일 형식: PNG"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. 格式：PNG"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. 格式：PNG"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. 格式：PNG"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. Format: PNG"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. 格式：PNG"
           }
         }
       }
     },
-    "frames": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frames:"
+    "frames" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frames:"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frames:"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frames:"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Images :"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Images :"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フレーム："
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フレーム："
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "프레임:"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "프레임:"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "帧数："
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帧数："
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "畫格："
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Frames:"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "畫格："
           }
         }
       }
     },
-    "heightRequirement": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. Höhe: 36px"
+    "heightRequirement" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. Höhe: 36px"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. Height: 36px"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. Height: 36px"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. Hauteur : 36px"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. Hauteur : 36px"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. 高さ：36px"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. 高さ：36px"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. 높이: 36px"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. 높이: 36px"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. 高度：36 像素"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. 高度：36 像素"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. 高度：36 像素"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. Height: 36px"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. 高度：36 像素"
           }
         }
       }
     },
-    "preview": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vorschau:"
+    "preview" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorschau:"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preview:"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preview:"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aperçus :"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aperçus :"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プレビュー："
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレビュー："
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "미리보기:"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리보기:"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "预览："
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预览："
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "預覽："
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preview:"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽："
           }
         }
       }
     },
-    "requirements": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anforderungen:"
+    "requirements" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anforderungen:"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Requirements:"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Requirements:"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Exigences :"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exigences :"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "規格要件："
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規格要件："
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "요구 사항:"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요구 사항:"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "規格要求："
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規格要求："
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "規格要求："
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Requirements:"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "規格要求："
           }
         }
       }
     },
-    "runnerName": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Läufer Name:"
+    "runnerName" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Läufer Name:"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Runner Name:"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Runner Name:"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nom du Coureur :"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom du Coureur :"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ランナー名："
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ランナー名："
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "러너 이름:"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "러너 이름:"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "跑者名称："
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跑者名称："
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "跑者名稱："
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Corredor Name:"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跑者名稱："
           }
         }
       }
     },
-    "selfMadeRunnersTitle": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selbsterstellte Läufer"
+    "selfMadeRunnersTitle" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selbsterstellte Läufer"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Self-Made Runners"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Self-Made Runners"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coureurs Personnalisés"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coureurs Personnalisés"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自作ランナー"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自作ランナー"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "커스텀 러너"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커스텀 러너"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自制跑者"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自制跑者"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自製跑者"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Self-Made Corredors"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自製跑者"
           }
         }
       }
     },
-    "toAdd": {
-      "generatesSymbol": false,
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Um sie hinzuzufügen, müssen Sie diese Funktion im Runners Store erwerben."
+    "toAdd" : {
+      "generatesSymbol" : false,
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Um sie hinzuzufügen, müssen Sie diese Funktion im Runners Store erwerben."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To add, you must purchase this function in the Runners Store."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To add, you must purchase this function in the Runners Store."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pour ajouter, vous devez acheter cette fonction dans le Magasin de Coureurs."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pour ajouter, vous devez acheter cette fonction dans le Magasin de Coureurs."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "追加するには、本機能をランナーストアで購入する必要があります。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加するには、本機能をランナーストアで購入する必要があります。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "추가하시려면 러너 스토어에서 커스텀 러너 기능을 구매해야 합니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추가하시려면 러너 스토어에서 커스텀 러너 기능을 구매해야 합니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "如需此功能，请在跑者商店购买。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如需此功能，请在跑者商店购买。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "如需添加跑者，請在跑者商店購買。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To add, you must purchase this function in the Corredors Store."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如需添加跑者，請在跑者商店購買。"
           }
         }
       }
     },
-    "useOriginalColor": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Originalfarbe verwenden"
+    "useOriginalColor" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Originalfarbe verwenden"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use original color"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use original color"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utiliser la couleur d’origine"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utiliser la couleur d’origine"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "画像の色をそのまま使用する"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像の色をそのまま使用する"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기본 색상 사용"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본 색상 사용"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用原始颜色"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用原始颜色"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用原始顏色"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use original color"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用原始顏色"
           }
         }
       }
     },
-    "violateRequirements": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Das geladene Bild verstößt gegen einige Anforderungen."
+    "violateRequirements" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das geladene Bild verstößt gegen einige Anforderungen."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The loaded image violates some requirements."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The loaded image violates some requirements."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "L’image chargé ne correspond pas aux exigences."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’image chargé ne correspond pas aux exigences."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "読み込まれた画像は規格要件を満たしていません。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読み込まれた画像は規格要件を満たしていません。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "해당 이미지는 규격 요건에 부합하지 않습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "해당 이미지는 규격 요건에 부합하지 않습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所加载的图片不满足部分規格要求。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所加载的图片不满足部分規格要求。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "所載入的圖片不符合某些規格要求。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The loaded image violates some requirements."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所載入的圖片不符合某些規格要求。"
           }
         }
       }
     },
-    "violateUpperLimit": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Anzahl der Frames hat die Obergrenze erreicht."
+    "violateUpperLimit" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Anzahl der Frames hat die Obergrenze erreicht."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The number of frames has reached the upper limit."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The number of frames has reached the upper limit."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Le nombre d’image a atteint la limite maximale."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le nombre d’image a atteint la limite maximale."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フレーム数が上限に達しています。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フレーム数が上限に達しています。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "프레임 수가 제한 범위를 초과했습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "프레임 수가 제한 범위를 초과했습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "帧数已达到最大上限。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帧数已达到最大上限。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "畫格已經達到上限。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The number of frames has reached the upper limit."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "畫格已經達到上限。"
           }
         }
       }
     },
-    "widthRequirement": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. Breite: 10~100px"
+    "widthRequirement" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. Breite: 10~100px"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. Width: 10~100px"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. Width: 10~100px"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. Largeur : 10~100px"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. Largeur : 10~100px"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. 幅：10~100px"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. 幅：10~100px"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. 너비: 10~100px"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. 너비: 10~100px"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. 宽度：10~100 像素"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. 宽度：10~100 像素"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. 寬度：10~100 像素"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. Width: 10~100px"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. 寬度：10~100 像素"
           }
         }
       }
     }
   },
-  "version": "1.1"
+  "version" : "1.1"
 }

--- a/Sources/RunCatLocalization/Resources/SelfMadeRunners.xcstrings
+++ b/Sources/RunCatLocalization/Resources/SelfMadeRunners.xcstrings
@@ -1,884 +1,998 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "add" : {
-      "generatesSymbol" : false,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinzufügen"
+  "sourceLanguage": "en",
+  "strings": {
+    "add": {
+      "generatesSymbol": false,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzufügen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "追加"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "추가"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추가"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加"
-          }
-        }
-      }
-    },
-    "addedRunners" : {
-      "generatesSymbol" : false,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinzugefügte Läufer:"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Added Runners:"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coureurs ajoutés :"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "追加済みのランナー："
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "추가된 러너:"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已添加的跑者："
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已添加的跑者："
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
           }
         }
       }
     },
-    "addErrorTitle" : {
-      "generatesSymbol" : false,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinzufügungsfehler"
+    "addedRunners": {
+      "generatesSymbol": false,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzugefügte Läufer:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Addition Error"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Added Runners:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur lors de l'ajout"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coureurs ajoutés :"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ランナー追加エラー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加済みのランナー："
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "추가 오류"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추가된 러너:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法添加"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已添加的跑者："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加失敗"
-          }
-        }
-      }
-    },
-    "color" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Farbe:"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已添加的跑者："
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Color:"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couleur :"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "色："
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "색상:"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "颜色："
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顏色："
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Added Corredors:"
           }
         }
       }
     },
-    "conflictName" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieser Läufername wird bereits verwendet."
+    "addErrorTitle": {
+      "generatesSymbol": false,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinzufügungsfehler"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This runner name is already in use."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Addition Error"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ce nom de coureur est déjà utilisé."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur lors de l'ajout"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "この名前はすでに使用されています。別の名前を使用してください。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ランナー追加エラー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이미 사용중인 러너 이름입니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추가 오류"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "该跑者名称已被使用。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法添加"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此跑者名稱已被使用。"
-          }
-        }
-      }
-    },
-    "failedToEncodeImages" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler beim Encodieren der Bilder."
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加失敗"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to encode images."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L’encodage de l’image a échoué."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像のエンコードに失敗しました。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이미지를 인코딩하지 못했습니다."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "图片编码失败。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "編碼圖片失敗。"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Addition Error"
           }
         }
       }
     },
-    "failedToSave" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler beim Speichern des selbsterstellten Läufers."
+    "color": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbe:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to save the self-made runner."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L’enregistrement du coureur personnalisé a échoué."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couleur :"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自作ランナーの保存に失敗しました。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "色："
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "커스텀 러너 저장에 실패했습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "색상:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存自制跑者失败。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "颜色："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "儲存自製跑者失敗。"
-          }
-        }
-      }
-    },
-    "formatRequirement" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1. Format: PNG"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顏色："
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1. Format: PNG"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1. Format : PNG"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1. フォーマット：PNG"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1. 파일 형식: PNG"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1. 格式：PNG"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1. 格式：PNG"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color:"
           }
         }
       }
     },
-    "frames" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frames:"
+    "conflictName": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Läufername wird bereits verwendet."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frames:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This runner name is already in use."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Images :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ce nom de coureur est déjà utilisé."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フレーム："
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この名前はすでに使用されています。別の名前を使用してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "프레임:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이미 사용중인 러너 이름입니다."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "帧数："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该跑者名称已被使用。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "畫格："
-          }
-        }
-      }
-    },
-    "heightRequirement" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. Höhe: 36px"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此跑者名稱已被使用。"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. Height: 36px"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. Hauteur : 36px"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. 高さ：36px"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. 높이: 36px"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. 高度：36 像素"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. 高度：36 像素"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This corredor name is already in use."
           }
         }
       }
     },
-    "preview" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorschau:"
+    "failedToEncodeImages": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler beim Encodieren der Bilder."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preview:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to encode images."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aperçus :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’encodage de l’image a échoué."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プレビュー："
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像のエンコードに失敗しました。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "미리보기:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이미지를 인코딩하지 못했습니다."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "预览："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "图片编码失败。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "預覽："
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編碼圖片失敗。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to encode images."
           }
         }
       }
     },
-    "requirements" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anforderungen:"
+    "failedToSave": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler beim Speichern des selbsterstellten Läufers."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requirements:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to save the self-made runner."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exigences :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’enregistrement du coureur personnalisé a échoué."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "規格要件："
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自作ランナーの保存に失敗しました。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "요구 사항:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "커스텀 러너 저장에 실패했습니다."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "規格要求："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存自制跑者失败。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "規格要求："
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存自製跑者失敗。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to save the self-made corredor."
           }
         }
       }
     },
-    "runnerName" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Läufer Name:"
+    "formatRequirement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Format: PNG"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Runner Name:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Format: PNG"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nom du Coureur :"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Format : PNG"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ランナー名："
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. フォーマット：PNG"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "러너 이름:"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 파일 형식: PNG"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跑者名称："
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 格式：PNG"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跑者名稱："
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 格式：PNG"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Format: PNG"
           }
         }
       }
     },
-    "selfMadeRunnersTitle" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selbsterstellte Läufer"
+    "frames": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frames:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Self-Made Runners"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frames:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coureurs Personnalisés"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Images :"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自作ランナー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フレーム："
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "커스텀 러너"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프레임:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自制跑者"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "帧数："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自製跑者"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "畫格："
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frames:"
           }
         }
       }
     },
-    "toAdd" : {
-      "generatesSymbol" : false,
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Um sie hinzuzufügen, müssen Sie diese Funktion im Runners Store erwerben."
+    "heightRequirement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Höhe: 36px"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To add, you must purchase this function in the Runners Store."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Height: 36px"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pour ajouter, vous devez acheter cette fonction dans le Magasin de Coureurs."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Hauteur : 36px"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "追加するには、本機能をランナーストアで購入する必要があります。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 高さ：36px"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "추가하시려면 러너 스토어에서 커스텀 러너 기능을 구매해야 합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 높이: 36px"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如需此功能，请在跑者商店购买。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 高度：36 像素"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如需添加跑者，請在跑者商店購買。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 高度：36 像素"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Height: 36px"
           }
         }
       }
     },
-    "useOriginalColor" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Originalfarbe verwenden"
+    "preview": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorschau:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use original color"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preview:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utiliser la couleur d’origine"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aperçus :"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像の色をそのまま使用する"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プレビュー："
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기본 색상 사용"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "미리보기:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用原始颜色"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "预览："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用原始顏色"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預覽："
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preview:"
           }
         }
       }
     },
-    "violateRequirements" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das geladene Bild verstößt gegen einige Anforderungen."
+    "requirements": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anforderungen:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The loaded image violates some requirements."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requirements:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L’image chargé ne correspond pas aux exigences."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exigences :"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "読み込まれた画像は規格要件を満たしていません。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "規格要件："
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "해당 이미지는 규격 요건에 부합하지 않습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요구 사항:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所加载的图片不满足部分規格要求。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "規格要求："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所載入的圖片不符合某些規格要求。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "規格要求："
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requirements:"
           }
         }
       }
     },
-    "violateUpperLimit" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Anzahl der Frames hat die Obergrenze erreicht."
+    "runnerName": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läufer Name:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The number of frames has reached the upper limit."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runner Name:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le nombre d’image a atteint la limite maximale."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom du Coureur :"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フレーム数が上限に達しています。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ランナー名："
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "프레임 수가 제한 범위를 초과했습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "러너 이름:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "帧数已达到最大上限。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跑者名称："
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "畫格已經達到上限。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跑者名稱："
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corredor Name:"
           }
         }
       }
     },
-    "widthRequirement" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3. Breite: 10~100px"
+    "selfMadeRunnersTitle": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selbsterstellte Läufer"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3. Width: 10~100px"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Self-Made Runners"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3. Largeur : 10~100px"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coureurs Personnalisés"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3. 幅：10~100px"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自作ランナー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3. 너비: 10~100px"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "커스텀 러너"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3. 宽度：10~100 像素"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自制跑者"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3. 寬度：10~100 像素"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自製跑者"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Self-Made Corredors"
+          }
+        }
+      }
+    },
+    "toAdd": {
+      "generatesSymbol": false,
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um sie hinzuzufügen, müssen Sie diese Funktion im Runners Store erwerben."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To add, you must purchase this function in the Runners Store."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pour ajouter, vous devez acheter cette fonction dans le Magasin de Coureurs."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加するには、本機能をランナーストアで購入する必要があります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추가하시려면 러너 스토어에서 커스텀 러너 기능을 구매해야 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如需此功能，请在跑者商店购买。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如需添加跑者，請在跑者商店購買。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To add, you must purchase this function in the Corredors Store."
+          }
+        }
+      }
+    },
+    "useOriginalColor": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Originalfarbe verwenden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use original color"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser la couleur d’origine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像の色をそのまま使用する"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 색상 사용"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用原始颜色"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用原始顏色"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use original color"
+          }
+        }
+      }
+    },
+    "violateRequirements": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das geladene Bild verstößt gegen einige Anforderungen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The loaded image violates some requirements."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’image chargé ne correspond pas aux exigences."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み込まれた画像は規格要件を満たしていません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "해당 이미지는 규격 요건에 부합하지 않습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所加载的图片不满足部分規格要求。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所載入的圖片不符合某些規格要求。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The loaded image violates some requirements."
+          }
+        }
+      }
+    },
+    "violateUpperLimit": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Anzahl der Frames hat die Obergrenze erreicht."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The number of frames has reached the upper limit."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le nombre d’image a atteint la limite maximale."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フレーム数が上限に達しています。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프레임 수가 제한 범위를 초과했습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "帧数已达到最大上限。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "畫格已經達到上限。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The number of frames has reached the upper limit."
+          }
+        }
+      }
+    },
+    "widthRequirement": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Breite: 10~100px"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Width: 10~100px"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Largeur : 10~100px"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 幅：10~100px"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 너비: 10~100px"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 宽度：10~100 像素"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 寬度：10~100 像素"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Width: 10~100px"
           }
         }
       }
     }
   },
-  "version" : "1.1"
+  "version": "1.1"
 }

--- a/Sources/RunCatLocalization/Resources/SelfMadeRunners.xcstrings
+++ b/Sources/RunCatLocalization/Resources/SelfMadeRunners.xcstrings
@@ -45,6 +45,12 @@
             "state" : "translated",
             "value" : "添加"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir"
+          }
         }
       }
     },
@@ -91,6 +97,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已添加的跑者："
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores añadidos:"
           }
         }
       }
@@ -139,6 +151,12 @@
             "state" : "translated",
             "value" : "添加失敗"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al añadir"
+          }
         }
       }
     },
@@ -184,6 +202,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顏色："
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Color:"
           }
         }
       }
@@ -231,6 +255,12 @@
             "state" : "translated",
             "value" : "此跑者名稱已被使用。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este nombre de corredor ya está en uso."
+          }
         }
       }
     },
@@ -276,6 +306,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "編碼圖片失敗。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al codificar las imágenes."
           }
         }
       }
@@ -323,6 +359,12 @@
             "state" : "translated",
             "value" : "儲存自製跑者失敗。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al guardar el corredor personalizado."
+          }
         }
       }
     },
@@ -368,6 +410,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "1. 格式：PNG"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. Formato: PNG"
           }
         }
       }
@@ -415,6 +463,12 @@
             "state" : "translated",
             "value" : "畫格："
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fotogramas:"
+          }
         }
       }
     },
@@ -460,6 +514,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "2. 高度：36 像素"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. Altura: 36 píxeles"
           }
         }
       }
@@ -507,6 +567,12 @@
             "state" : "translated",
             "value" : "預覽："
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vista previa:"
+          }
         }
       }
     },
@@ -552,6 +618,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "規格要求："
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Requisitos:"
           }
         }
       }
@@ -599,6 +671,12 @@
             "state" : "translated",
             "value" : "跑者名稱："
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre del corredor:"
+          }
         }
       }
     },
@@ -644,6 +722,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自製跑者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corredores personalizados"
           }
         }
       }
@@ -692,6 +776,12 @@
             "state" : "translated",
             "value" : "如需添加跑者，請在跑者商店購買。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para añadir, debes comprar esta función en la Tienda de Corredores."
+          }
         }
       }
     },
@@ -737,6 +827,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用原始顏色"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usar color original"
           }
         }
       }
@@ -784,6 +880,12 @@
             "state" : "translated",
             "value" : "所載入的圖片不符合某些規格要求。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La imagen cargada incumple algunos requisitos."
+          }
         }
       }
     },
@@ -830,6 +932,12 @@
             "state" : "translated",
             "value" : "畫格已經達到上限。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El número de fotogramas ha alcanzado el límite máximo."
+          }
         }
       }
     },
@@ -875,6 +983,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "3. 寬度：10~100 像素"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. Ancho: 10~100 píxeles"
           }
         }
       }

--- a/Sources/RunCatLocalization/Resources/SystemInfoBar.xcstrings
+++ b/Sources/RunCatLocalization/Resources/SystemInfoBar.xcstrings
@@ -1,578 +1,512 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "available": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verfügbar"
+  "sourceLanguage" : "en",
+  "strings" : {
+    "available" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verfügbar"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Available"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Available"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disponible"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disponible"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "利用可能"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用可能"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사용 가능"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용 가능"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "可用"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "可用"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disponible"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用"
           }
         }
       }
     },
-    "barGraph": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Balkendiagramm"
+    "barGraph" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Balkendiagramm"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bar Graph"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bar Graph"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Barre"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barre"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "棒グラフ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "棒グラフ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "바형 그래프"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "바형 그래프"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "条形图"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "条形图"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "長條圖"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gráfico de barras"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長條圖"
           }
         }
       }
     },
-    "onlyIcon": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nur Icon"
+    "onlyIcon" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nur Icon"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only Icon"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only Icon"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Icône seulement"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Icône seulement"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アイコンのみ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アイコンのみ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "아이콘만"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아이콘만"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仅图标"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅图标"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "僅圖示"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solo icono"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅圖示"
           }
         }
       }
     },
-    "percentage": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prozent"
+    "percentage" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prozent"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Percentage"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Percentage"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pourcentage"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pourcentage"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "パーセンテージ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パーセンテージ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "퍼센트"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "퍼센트"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "百分比"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "百分比"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "百分比"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Porcentaje"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "百分比"
           }
         }
       }
     },
-    "pieChart": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kuchendiagramm"
+    "pieChart" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kuchendiagramm"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pie Chart"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pie Chart"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cercle"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cercle"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "円グラフ"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "円グラフ"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "원형 차트"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "원형 차트"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "饼图"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "饼图"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "圓餅圖"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gráfico circular"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圓餅圖"
           }
         }
       }
     },
-    "showBatteryState": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Batteriestatus anzeigen"
+    "showBatteryState" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batteriestatus anzeigen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show Battery State"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Battery State"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Afficher le niveau de batterie"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le niveau de batterie"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "バッテリー状態を表示"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バッテリー状態を表示"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "배터리 상태 보기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "배터리 상태 보기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "显示电池状态"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示电池状态"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "顯示電池狀態"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar estado de la batería"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示電池狀態"
           }
         }
       }
     },
-    "showCPUUsage": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CPU-Auslastung anzeigen"
+    "showCPUUsage" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CPU-Auslastung anzeigen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show CPU Usage"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show CPU Usage"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Afficher l’utilisation du CPU"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l’utilisation du CPU"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CPU負荷を表示"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CPU負荷を表示"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "CPU 사용량 보기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CPU 사용량 보기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "显示 CPU 使用率"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示 CPU 使用率"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "顯示 CPU 使用率"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar uso de CPU"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示 CPU 使用率"
           }
         }
       }
     },
-    "showMemoryPerformance": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Speicherleistung anzeigen"
+    "showMemoryPerformance" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speicherleistung anzeigen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show Memory Performance"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Memory Performance"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Afficher l’utilisation de la mémoire"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l’utilisation de la mémoire"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "メモリ性能を表示"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモリ性能を表示"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "메모리 성능 보기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메모리 성능 보기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "显示内存性能"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示内存性能"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "顯示記憶體效能"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar rendimiento de memoria"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示記憶體效能"
           }
         }
       }
     },
-    "showNetworkSpeed": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Netzwerkgeschwindigkeit anzeigen"
+    "showNetworkSpeed" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Netzwerkgeschwindigkeit anzeigen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show Network Speed"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Network Speed"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Afficher la vitesse du réseau"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher la vitesse du réseau"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワーク速度を表示"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネットワーク速度を表示"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "네트워크 속도 보기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "네트워크 속도 보기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "显示网络速度"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示网络速度"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "顯示網路速度"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar velocidad de red"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示網路速度"
           }
         }
       }
     },
-    "showStorageCapacity": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Speicherkapazität anzeigen"
+    "showStorageCapacity" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speicherkapazität anzeigen"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show Storage Capacity"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Storage Capacity"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Afficher l’utilisation du stockage"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher l’utilisation du stockage"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ストレージ容量を表示"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストレージ容量を表示"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "저장 용량 보기"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저장 용량 보기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "显示存储容量"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示存储容量"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "顯示儲存空間容量"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mostrar capacidad de almacenamiento"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示儲存空間容量"
           }
         }
       }
     },
-    "used": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verwendet"
+    "used" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwendet"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Used"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Used"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utilisé"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisé"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用中"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用中"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사용됨"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용됨"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已用"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已用"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已使用"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usado"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已使用"
           }
         }
       }
     }
   },
-  "version": "1.0"
+  "version" : "1.0"
 }

--- a/Sources/RunCatLocalization/Resources/SystemInfoBar.xcstrings
+++ b/Sources/RunCatLocalization/Resources/SystemInfoBar.xcstrings
@@ -1,512 +1,578 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "available" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verfügbar"
+  "sourceLanguage": "en",
+  "strings": {
+    "available": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verfügbar"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Available"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Available"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disponible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disponible"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "利用可能"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사용 가능"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 가능"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "可用"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可用"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "可用"
-          }
-        }
-      }
-    },
-    "barGraph" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Balkendiagramm"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可用"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bar Graph"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Barre"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "棒グラフ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "바형 그래프"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "条形图"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "長條圖"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disponible"
           }
         }
       }
     },
-    "onlyIcon" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nur Icon"
+    "barGraph": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Balkendiagramm"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Only Icon"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bar Graph"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Icône seulement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Barre"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アイコンのみ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "棒グラフ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "아이콘만"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "바형 그래프"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "仅图标"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "条形图"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "僅圖示"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "長條圖"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gráfico de barras"
           }
         }
       }
     },
-    "percentage" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prozent"
+    "onlyIcon": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur Icon"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Percentage"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Only Icon"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pourcentage"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icône seulement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パーセンテージ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アイコンのみ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "퍼센트"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아이콘만"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "百分比"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅图标"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "百分比"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "僅圖示"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo icono"
           }
         }
       }
     },
-    "pieChart" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kuchendiagramm"
+    "percentage": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prozent"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pie Chart"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Percentage"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cercle"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pourcentage"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "円グラフ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パーセンテージ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "원형 차트"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "퍼센트"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "饼图"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "百分比"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "圓餅圖"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "百分比"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Porcentaje"
           }
         }
       }
     },
-    "showBatteryState" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Batteriestatus anzeigen"
+    "pieChart": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kuchendiagramm"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Battery State"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pie Chart"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher le niveau de batterie"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cercle"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "バッテリー状態を表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "円グラフ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "배터리 상태 보기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "원형 차트"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示电池状态"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "饼图"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示電池狀態"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圓餅圖"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gráfico circular"
           }
         }
       }
     },
-    "showCPUUsage" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CPU-Auslastung anzeigen"
+    "showBatteryState": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Batteriestatus anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show CPU Usage"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Battery State"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher l’utilisation du CPU"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher le niveau de batterie"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CPU負荷を表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バッテリー状態を表示"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CPU 사용량 보기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "배터리 상태 보기"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示 CPU 使用率"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示电池状态"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示 CPU 使用率"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示電池狀態"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar estado de la batería"
           }
         }
       }
     },
-    "showMemoryPerformance" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speicherleistung anzeigen"
+    "showCPUUsage": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CPU-Auslastung anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Memory Performance"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show CPU Usage"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher l’utilisation de la mémoire"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher l’utilisation du CPU"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メモリ性能を表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CPU負荷を表示"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메모리 성능 보기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CPU 사용량 보기"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示内存性能"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示 CPU 使用率"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示記憶體效能"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示 CPU 使用率"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar uso de CPU"
           }
         }
       }
     },
-    "showNetworkSpeed" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Netzwerkgeschwindigkeit anzeigen"
+    "showMemoryPerformance": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speicherleistung anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Network Speed"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Memory Performance"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher la vitesse du réseau"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher l’utilisation de la mémoire"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ネットワーク速度を表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メモリ性能を表示"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "네트워크 속도 보기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메모리 성능 보기"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示网络速度"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示内存性能"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示網路速度"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示記憶體效能"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar rendimiento de memoria"
           }
         }
       }
     },
-    "showStorageCapacity" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speicherkapazität anzeigen"
+    "showNetworkSpeed": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerkgeschwindigkeit anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Storage Capacity"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Network Speed"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher l’utilisation du stockage"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher la vitesse du réseau"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ストレージ容量を表示"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク速度を表示"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "저장 용량 보기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "네트워크 속도 보기"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示存储容量"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示网络速度"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示儲存空間容量"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示網路速度"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar velocidad de red"
           }
         }
       }
     },
-    "used" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verwendet"
+    "showStorageCapacity": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speicherkapazität anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Used"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Storage Capacity"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher l’utilisation du stockage"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "使用中"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ストレージ容量を表示"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사용됨"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장 용량 보기"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已用"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示存储容量"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已使用"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示儲存空間容量"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar capacidad de almacenamiento"
+          }
+        }
+      }
+    },
+    "used": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwendet"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Used"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용됨"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已用"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已使用"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usado"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/Sources/RunCatLocalization/Resources/SystemInfoBar.xcstrings
+++ b/Sources/RunCatLocalization/Resources/SystemInfoBar.xcstrings
@@ -44,6 +44,12 @@
             "state" : "translated",
             "value" : "可用"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disponible"
+          }
         }
       }
     },
@@ -89,6 +95,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "長條圖"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gráfico de barras"
           }
         }
       }
@@ -136,6 +148,12 @@
             "state" : "translated",
             "value" : "僅圖示"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo icono"
+          }
         }
       }
     },
@@ -181,6 +199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "百分比"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Porcentaje"
           }
         }
       }
@@ -228,6 +252,12 @@
             "state" : "translated",
             "value" : "圓餅圖"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gráfico circular"
+          }
         }
       }
     },
@@ -273,6 +303,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示電池狀態"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar estado de la batería"
           }
         }
       }
@@ -320,6 +356,12 @@
             "state" : "translated",
             "value" : "顯示 CPU 使用率"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar uso de CPU"
+          }
         }
       }
     },
@@ -365,6 +407,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示記憶體效能"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar rendimiento de memoria"
           }
         }
       }
@@ -412,6 +460,12 @@
             "state" : "translated",
             "value" : "顯示網路速度"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar velocidad de red"
+          }
         }
       }
     },
@@ -458,6 +512,12 @@
             "state" : "translated",
             "value" : "顯示儲存空間容量"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar capacidad de almacenamiento"
+          }
         }
       }
     },
@@ -503,6 +563,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已使用"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usado"
           }
         }
       }

--- a/Sources/RunCatLocalization/Resources/SystemInfoSettings.xcstrings
+++ b/Sources/RunCatLocalization/Resources/SystemInfoSettings.xcstrings
@@ -1,512 +1,578 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "activate" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktivieren"
+  "sourceLanguage": "en",
+  "strings": {
+    "activate": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activate"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activate"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効にする"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効にする"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "활성화"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활성화"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "啟用"
-          }
-        }
-      }
-    },
-    "activateSystemInfoBarMessage" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wenn Sie ein MacBook mit einer Notch verwenden, kann es sein, dass Sie die Systeminformationsleiste in der Menüleiste nicht sehen oder nicht auf andere Menüleistenelemente zugreifen können."
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If you use MacBook with a notch, you may not be able to see the System Info Bar on the menu bar or not be able to access other menu bar items."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si vous utilisez un MacBook avec une encoche, vous pourriez ne pas être capable de voir la Barre des Infos Système ou d’autre icônes dans la barre des menus."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ノッチ付きのMacBookを使用している場合、メニューバー上にシステム情報バーが表示できないことや、他のメニューバー上のアイテムにアクセスできなくなることがあります。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "상단 노치가 있는 맥북을 사용중이라면, 메뉴바의 시스템 정보가 보이지 않거나, 메뉴바의 항목을 선택하지 못할 수도 있습니다."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果您使用的是带有刘海的 MacBook，可能无法在菜单栏中看到系统信息栏，或无法访问其他菜单栏项目。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果您使用的是有瀏海的 MacBook，可能無法在選單列中看到系統資訊列或無法存取其他選單列項目。"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar"
           }
         }
       }
     },
-    "activateSystemInfoBarTitle" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinweise zur Verwendung der Systeminformationsleiste"
+    "activateSystemInfoBarMessage": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn Sie ein MacBook mit einer Notch verwenden, kann es sein, dass Sie die Systeminformationsleiste in der Menüleiste nicht sehen oder nicht auf andere Menüleistenelemente zugreifen können."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notes on using System Info Bar"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you use MacBook with a notch, you may not be able to see the System Info Bar on the menu bar or not be able to access other menu bar items."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "À noter pour l’utilisation de la Barre des Infos Système"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si vous utilisez un MacBook avec une encoche, vous pourriez ne pas être capable de voir la Barre des Infos Système ou d’autre icônes dans la barre des menus."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システム情報バーを使用する際の注意事項"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ノッチ付きのMacBookを使用している場合、メニューバー上にシステム情報バーが表示できないことや、他のメニューバー上のアイテムにアクセスできなくなることがあります。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "시스템 정보 사용 시 주의사항"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상단 노치가 있는 맥북을 사용중이라면, 메뉴바의 시스템 정보가 보이지 않거나, 메뉴바의 항목을 선택하지 못할 수도 있습니다."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系统信息栏使用说明"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果您使用的是带有刘海的 MacBook，可能无法在菜单栏中看到系统信息栏，或无法访问其他菜单栏项目。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系統資訊列使用說明"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果您使用的是有瀏海的 MacBook，可能無法在選單列中看到系統資訊列或無法存取其他選單列項目。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you use MacBook with a notch, you may not be able to see the Información del sistema Bar on the menu bar or not be able to access other menu bar items."
           }
         }
       }
     },
-    "batteryState" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Batteriestatus"
+    "activateSystemInfoBarTitle": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinweise zur Verwendung der Systeminformationsleiste"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Battery State"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notes on using System Info Bar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niveau de batterie"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À noter pour l’utilisation de la Barre des Infos Système"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "バッテリー状態"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム情報バーを使用する際の注意事項"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "배터리 상태"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 정보 사용 시 주의사항"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "电池状态"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统信息栏使用说明"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "電池狀態"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系統資訊列使用說明"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notes on using Información del sistema Bar"
           }
         }
       }
     },
-    "changedMyMind" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ich habe meine Meinung geändert"
+    "batteryState": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Batteriestatus"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Changed my mind"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Battery State"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mon avis a changé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niveau de batterie"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "やめておく"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バッテリー状態"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "그냥 둘래요"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "배터리 상태"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "我改变主意了"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "电池状态"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "我改變主意了"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電池狀態"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado de la batería"
           }
         }
       }
     },
-    "experimentalFeature" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Experimentelle Funktion"
+    "changedMyMind": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ich habe meine Meinung geändert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Experimental feature"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changed my mind"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fonction expérimentale"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mon avis a changé"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "試験的機能"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "やめておく"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "실험적 기능"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "그냥 둘래요"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "实验性功能"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我改变主意了"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "實驗性功能"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我改變主意了"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambié de opinión"
           }
         }
       }
     },
-    "memoryPerformance" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speicherleistung"
+    "experimentalFeature": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experimentelle Funktion"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Memory Performance"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experimental feature"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisation de la mémoire"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonction expérimentale"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メモリ性能"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "試験的機能"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메모리 성능"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실험적 기능"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "内存性能"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "实验性功能"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "記憶體效能"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "實驗性功能"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experimental feature"
           }
         }
       }
     },
-    "monitoring" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überwachung"
+    "memoryPerformance": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speicherleistung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Monitoring"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memory Performance"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Affichage des informations"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utilisation de la mémoire"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "モニタリング"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メモリ性能"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "모니터링"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메모리 성능"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "监测"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内存性能"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "監控"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記憶體效能"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rendimiento de memoria"
           }
         }
       }
     },
-    "networkConnection" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Netzwerkverbindung"
+    "monitoring": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überwachung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Network Connection"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitoring"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informations du réseau"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Affichage des informations"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ネットワーク接続状況"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モニタリング"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "네트워크 연결"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모니터링"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "网络连接"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "监测"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "網路連線"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "監控"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monitoreo"
           }
         }
       }
     },
-    "storageCapacity" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speicherkapazität"
+    "networkConnection": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Netzwerkverbindung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Storage Capacity"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Network Connection"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capacité de stockage"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informations du réseau"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ストレージ容量"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク接続状況"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "저장 용량"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "네트워크 연결"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "存储容量"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网络连接"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "儲存空間容量"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網路連線"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conexión de red"
           }
         }
       }
     },
-    "systemInfoBar" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System-Infoleiste (β)"
+    "storageCapacity": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speicherkapazität"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System Info Bar (β)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Storage Capacity"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Barre des Infos Système (β)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capacité de stockage"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システム情報バー（β）"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ストレージ容量"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "시스템 정보 (베타)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장 용량"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系统信息栏（β）"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存储容量"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系統資訊列 (β)"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存空間容量"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capacidad de almacenamiento"
+          }
+        }
+      }
+    },
+    "systemInfoBar": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System-Infoleiste (β)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Info Bar (β)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Barre des Infos Système (β)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム情報バー（β）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 정보 (베타)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统信息栏（β）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系統資訊列 (β)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Barra de información del sistema (β)"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/Sources/RunCatLocalization/Resources/SystemInfoSettings.xcstrings
+++ b/Sources/RunCatLocalization/Resources/SystemInfoSettings.xcstrings
@@ -1,578 +1,512 @@
 {
-  "sourceLanguage": "en",
-  "strings": {
-    "activate": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktivieren"
+  "sourceLanguage" : "en",
+  "strings" : {
+    "activate" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktivieren"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activate"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activate"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activer"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効にする"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効にする"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "활성화"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성화"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "启用"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "啟用"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activar"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用"
           }
         }
       }
     },
-    "activateSystemInfoBarMessage": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wenn Sie ein MacBook mit einer Notch verwenden, kann es sein, dass Sie die Systeminformationsleiste in der Menüleiste nicht sehen oder nicht auf andere Menüleistenelemente zugreifen können."
+    "activateSystemInfoBarMessage" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn Sie ein MacBook mit einer Notch verwenden, kann es sein, dass Sie die Systeminformationsleiste in der Menüleiste nicht sehen oder nicht auf andere Menüleistenelemente zugreifen können."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If you use MacBook with a notch, you may not be able to see the System Info Bar on the menu bar or not be able to access other menu bar items."
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If you use MacBook with a notch, you may not be able to see the System Info Bar on the menu bar or not be able to access other menu bar items."
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si vous utilisez un MacBook avec une encoche, vous pourriez ne pas être capable de voir la Barre des Infos Système ou d’autre icônes dans la barre des menus."
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si vous utilisez un MacBook avec une encoche, vous pourriez ne pas être capable de voir la Barre des Infos Système ou d’autre icônes dans la barre des menus."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ノッチ付きのMacBookを使用している場合、メニューバー上にシステム情報バーが表示できないことや、他のメニューバー上のアイテムにアクセスできなくなることがあります。"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ノッチ付きのMacBookを使用している場合、メニューバー上にシステム情報バーが表示できないことや、他のメニューバー上のアイテムにアクセスできなくなることがあります。"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "상단 노치가 있는 맥북을 사용중이라면, 메뉴바의 시스템 정보가 보이지 않거나, 메뉴바의 항목을 선택하지 못할 수도 있습니다."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상단 노치가 있는 맥북을 사용중이라면, 메뉴바의 시스템 정보가 보이지 않거나, 메뉴바의 항목을 선택하지 못할 수도 있습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "如果您使用的是带有刘海的 MacBook，可能无法在菜单栏中看到系统信息栏，或无法访问其他菜单栏项目。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果您使用的是带有刘海的 MacBook，可能无法在菜单栏中看到系统信息栏，或无法访问其他菜单栏项目。"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "如果您使用的是有瀏海的 MacBook，可能無法在選單列中看到系統資訊列或無法存取其他選單列項目。"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If you use MacBook with a notch, you may not be able to see the Información del sistema Bar on the menu bar or not be able to access other menu bar items."
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如果您使用的是有瀏海的 MacBook，可能無法在選單列中看到系統資訊列或無法存取其他選單列項目。"
           }
         }
       }
     },
-    "activateSystemInfoBarTitle": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hinweise zur Verwendung der Systeminformationsleiste"
+    "activateSystemInfoBarTitle" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hinweise zur Verwendung der Systeminformationsleiste"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notes on using System Info Bar"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notes on using System Info Bar"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "À noter pour l’utilisation de la Barre des Infos Système"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À noter pour l’utilisation de la Barre des Infos Système"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "システム情報バーを使用する際の注意事項"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム情報バーを使用する際の注意事項"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "시스템 정보 사용 시 주의사항"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시스템 정보 사용 시 주의사항"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "系统信息栏使用说明"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统信息栏使用说明"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "系統資訊列使用說明"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notes on using Información del sistema Bar"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統資訊列使用說明"
           }
         }
       }
     },
-    "batteryState": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Batteriestatus"
+    "batteryState" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batteriestatus"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Battery State"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Battery State"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Niveau de batterie"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niveau de batterie"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "バッテリー状態"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バッテリー状態"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "배터리 상태"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "배터리 상태"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "电池状态"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "电池状态"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "電池狀態"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estado de la batería"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電池狀態"
           }
         }
       }
     },
-    "changedMyMind": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ich habe meine Meinung geändert"
+    "changedMyMind" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ich habe meine Meinung geändert"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Changed my mind"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changed my mind"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mon avis a changé"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mon avis a changé"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "やめておく"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "やめておく"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "그냥 둘래요"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "그냥 둘래요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "我改变主意了"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我改变主意了"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "我改變主意了"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambié de opinión"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我改變主意了"
           }
         }
       }
     },
-    "experimentalFeature": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Experimentelle Funktion"
+    "experimentalFeature" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimentelle Funktion"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Experimental feature"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experimental feature"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fonction expérimentale"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fonction expérimentale"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "試験的機能"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "試験的機能"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "실험적 기능"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "실험적 기능"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "实验性功能"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "实验性功能"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "實驗性功能"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Experimental feature"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "實驗性功能"
           }
         }
       }
     },
-    "memoryPerformance": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Speicherleistung"
+    "memoryPerformance" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speicherleistung"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Memory Performance"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memory Performance"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utilisation de la mémoire"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisation de la mémoire"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "メモリ性能"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモリ性能"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "메모리 성능"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메모리 성능"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "内存性能"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "内存性能"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "記憶體效能"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rendimiento de memoria"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體效能"
           }
         }
       }
     },
-    "monitoring": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Überwachung"
+    "monitoring" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Überwachung"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monitoring"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monitoring"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Affichage des informations"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Affichage des informations"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "モニタリング"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モニタリング"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모니터링"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모니터링"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "监测"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "监测"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "監控"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Monitoreo"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "監控"
           }
         }
       }
     },
-    "networkConnection": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Netzwerkverbindung"
+    "networkConnection" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Netzwerkverbindung"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Network Connection"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network Connection"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informations du réseau"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informations du réseau"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ネットワーク接続状況"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネットワーク接続状況"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "네트워크 연결"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "네트워크 연결"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "网络连接"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网络连接"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "網路連線"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conexión de red"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網路連線"
           }
         }
       }
     },
-    "storageCapacity": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Speicherkapazität"
+    "storageCapacity" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speicherkapazität"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Storage Capacity"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Storage Capacity"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Capacité de stockage"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capacité de stockage"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ストレージ容量"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストレージ容量"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "저장 용량"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저장 용량"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "存储容量"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存储容量"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "儲存空間容量"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Capacidad de almacenamiento"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存空間容量"
           }
         }
       }
     },
-    "systemInfoBar": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "System-Infoleiste (β)"
+    "systemInfoBar" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System-Infoleiste (β)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "System Info Bar (β)"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System Info Bar (β)"
           }
         },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Barre des Infos Système (β)"
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barre des Infos Système (β)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "システム情報バー（β）"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム情報バー（β）"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "시스템 정보 (베타)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시스템 정보 (베타)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "系统信息栏（β）"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统信息栏（β）"
           }
         },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "系統資訊列 (β)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Barra de información del sistema (β)"
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統資訊列 (β)"
           }
         }
       }
     }
   },
-  "version": "1.0"
+  "version" : "1.0"
 }

--- a/Sources/RunCatLocalization/Resources/SystemInfoSettings.xcstrings
+++ b/Sources/RunCatLocalization/Resources/SystemInfoSettings.xcstrings
@@ -44,6 +44,12 @@
             "state" : "translated",
             "value" : "啟用"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar"
+          }
         }
       }
     },
@@ -89,6 +95,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "如果您使用的是有瀏海的 MacBook，可能無法在選單列中看到系統資訊列或無法存取其他選單列項目。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si usas un MacBook con notch, es posible que no puedas ver la Barra de información del sistema en la barra de menú o no puedas acceder a otros elementos de la barra de menú."
           }
         }
       }
@@ -136,6 +148,12 @@
             "state" : "translated",
             "value" : "系統資訊列使用說明"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notas sobre el uso de la Barra de información del sistema"
+          }
         }
       }
     },
@@ -181,6 +199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "電池狀態"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado de la batería"
           }
         }
       }
@@ -228,6 +252,12 @@
             "state" : "translated",
             "value" : "我改變主意了"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambié de opinión"
+          }
         }
       }
     },
@@ -273,6 +303,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "實驗性功能"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Función experimental"
           }
         }
       }
@@ -320,6 +356,12 @@
             "state" : "translated",
             "value" : "記憶體效能"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendimiento de memoria"
+          }
         }
       }
     },
@@ -365,6 +407,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "監控"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Monitoreo"
           }
         }
       }
@@ -412,6 +460,12 @@
             "state" : "translated",
             "value" : "網路連線"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conexión de red"
+          }
         }
       }
     },
@@ -458,6 +512,12 @@
             "state" : "translated",
             "value" : "儲存空間容量"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capacidad de almacenamiento"
+          }
         }
       }
     },
@@ -503,6 +563,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系統資訊列 (β)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barra de información del sistema (β)"
           }
         }
       }

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,6 +31,11 @@
               <span>Deutsch</span>
             </label>
             <label class="language-radio">
+              <input type="radio" name="language" value="es" />
+              <span class="flag">🇪🇸</span>
+              <span>Español</span>
+            </label>
+            <label class="language-radio">
               <input type="radio" name="language" value="fr" />
               <span class="flag">🇫🇷</span>
               <span>Français</span>

--- a/docs/script.js
+++ b/docs/script.js
@@ -9,7 +9,7 @@ class RunnerNamesViewer {
     this.primaryLanguage = "en";
 
     // Additional languages in alphabetical order by language code
-    this.supportedLanguages = ["de", "fr", "ja", "ko", "zh-Hans", "zh-Hant"];
+    this.supportedLanguages = ["de", "es", "fr", "ja", "ko", "zh-Hans", "zh-Hant"];
 
     // Selected additional language index (English is always selected)
     this.selectedLanguageIndex = 0; // First additional language by default
@@ -230,6 +230,7 @@ class RunnerNamesViewer {
     const additionalLang = this.supportedLanguages[this.selectedLanguageIndex];
     const langNames = {
       de: "Deutsch",
+      es: "Español",
       fr: "Français",
       ja: "日本語",
       ko: "한국어",


### PR DESCRIPTION
- Add Spanish (español) to RCLLanguage enum
- Add Spanish translations to all xcstrings files
- Update README.md to include Spanish in supported languages list
- Total: 199 strings translated to Spanish